### PR TITLE
Fix View For Mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
         <h2>MEETINGS SCHEDULE</h2>
         <br>
 
-        <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=westwoodrobotics%40gmail.com&amp;color=%23f64f00&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+        <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=westwoodrobotics%40gmail.com&amp;color=%23f64f00&amp;ctz=America%2FNew_York" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 
     </div>
 

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
         <h2>MEETINGS SCHEDULE</h2>
         <br>
 
-        <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=westwoodrobotics%40gmail.com&amp;color=%23f64f00&amp;ctz=America%2FNew_York" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+        <iframe src="https://calendar.google.com/calendar/embed?mode=AGENDA&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=westwoodrobotics%40gmail.com&amp;color=%23f64f00&amp;ctz=America%2FNew_York" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 
     </div>
 


### PR DESCRIPTION
Calendar now occupies entire width of screen and displays in agenda view, as to be more user-friendly.
I was working without a real text editor on my raspberry pi from my chromebook so this is pretty good