### PR TITLE
Changed calendar widget to weekly by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,8 +238,7 @@
         <h2>MEETINGS SCHEDULE</h2>
         <br>
 
-        <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=westwoodrobotics%40gmail.com&amp;color=%23f64f00&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
+        <iframe src="https://calendar.google.com/calendar/embed?title=Event%20Schedule&amp;showTitle=0&amp;showDate=0&amp;showCalendars=0&amp;showTz=0&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=westwoodrobotics%40gmail.com&amp;color=%23182C57&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
     </div>
 
     <!-- DONATE -->


### PR DESCRIPTION
Also enabled the print button, in case anyone ever needs it. Hopefully this should look better and be more useful for our purposes. This is in case you don't want to go with the alternate option of moving the calendar elsewhere that I wrote earlier.