### PR TITLE
Add scouting system documentation with interactive viewer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# 1757 Scouting System Documentation
+
+Documentation for FRC Team 1757's match scouting, data analysis, and strategy planning system.
+
+> [!TIP]
+> **First time?** Scouts should start with the [Competition Quick Start](competition-quickstart.md). Developers should start with [Setup & Deployment](setup-and-deployment.md).
+
+## For Scouts and Strategy
+
+| Guide | Description |
+|-------|-------------|
+| [Competition Quick Start](competition-quickstart.md) | One-page cheat sheet for event day — print this out |
+| [Scouting Form Guide](scouting-form.md) | How to fill out the scouting form during a match |
+| [Dashboard Guide](scouting-dashboard.md) | How to use every dashboard mode for analysis and strategy |
+| [Scout Assignments](scout-assignments.md) | How scout-to-match assignments work |
+
+## For Developers
+
+| Reference | Description |
+|-----------|-------------|
+| [Setup & Deployment](setup-and-deployment.md) | Environment variables, local dev, building, and deploying |
+| [Architecture](architecture.md) | Codebase structure, component map, and data flow |
+| [Data Format Reference](data-format-reference.md) | CSV schemas, timeline encoding, and API contracts |
+
+## For Everyone
+
+| Guide | Description |
+|-------|-------------|
+| [Troubleshooting](troubleshooting.md) | Common problems at competitions and how to fix them |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,137 @@
+# Architecture
+
+> SvelteKit static site with client-side data fetching from TBA, Statbotics, and Google Sheets. All processing happens in the browser — there is no backend server.
+
+[Back to docs index](README.md)
+
+## Tech Stack
+
+| Technology | Purpose |
+|------------|---------|
+| SvelteKit 2 | Application framework |
+| Svelte 4 | Component syntax (`export let`, `on:click`, `{#each}`) |
+| Tailwind CSS | Styling (dark theme, zinc-900 backgrounds) |
+| Chart.js + svelte-chartjs | Performance trend graphs |
+| @sveltejs/adapter-static | Builds to static HTML/JS for GitHub Pages |
+| GitHub Actions | Auto-deployment from `next` branch |
+
+## Project Structure
+
+```
+src/
+  routes/
+    scouting/+page.svelte                    # Scouting form (~560 lines)
+    scouting-dashboard/+page.svelte           # Main dashboard (~4300 lines)
+    scouting-assignments/+page.svelte         # Scout assignments (~940 lines)
+  components/
+    scoutingDashboard/
+      CoverageMap.svelte                      # Match coverage grid
+      CoverageMapButton.svelte                # Individual coverage cell with long-press
+      EventProgressMap.svelte                 # Quals prediction map with overrides
+      PlayoffProgressMap.svelte               # Playoff bracket visualization
+      RPCards.svelte                          # Ranking point prediction cards
+      SimulatorHeader.svelte                  # Simulator alliance header display
+      SimulatorTeamCard.svelte                # Team card with stats and autocomplete
+      ContextMenu.svelte                      # Right-click menu for simulator loading
+      OverrideContextMenu.svelte              # Right-click menu for match overrides
+      utils.js                                # Shared utilities
+static/
+  test-data/                                  # Fallback data for debug mode
+.github/
+  workflows/AutoDeploy.yml                    # GitHub Pages deployment
+```
+
+## Data Flow
+
+```
+Google Forms  →  Google Sheets  →  Published CSV  →  Dashboard (client-side fetch)
+                                                         ↕
+TBA API  ────────────────────────────────────────→  Dashboard (schedule, rankings, alliances)
+                                                         ↕
+Statbotics API  ─────────────────────────────────→  Dashboard (EPA, match predictions)
+                                                         ↕
+FRC Colors API  ─────────────────────────────────→  Dashboard (team color theming)
+```
+
+1. Scouts fill out the scouting form at `/scouting` during matches
+2. Form data submits to Google Forms, which populates a Google Sheet
+3. The dashboard fetches the Sheet as CSV via the published URL
+4. The dashboard also fetches TBA and Statbotics data for EPA, schedule, and rankings
+5. All data processing (filtering, sorting, aggregation, predictions) happens client-side
+
+## External APIs
+
+| API | Base URL | Auth | Used For |
+|-----|----------|------|----------|
+| The Blue Alliance | `thebluealliance.com/api/v3` | `X-TBA-Auth-Key` header | Schedule, rankings, OPRs, alliances, team details |
+| Statbotics | `api.statbotics.io/v3` | None (public) | EPA ratings, match predictions, year statistics |
+| FRC Colors | `api.frc-colors.com/v1` | None (public) | Team primary/secondary hex colors |
+| Google Sheets | Published CSV URL | None (public link) | Scouting data, pit data, scout roster |
+| Google Forms | Form submission URL | None | Scouting form target |
+
+## Key Patterns
+
+### Hold-to-Time Buttons
+
+The scouting form uses `mousedown`/`touchstart` to begin timing an action and `mouseup`/`touchend` to stop. Each press creates a `start` timeline entry and each release creates a `stop` entry. Duration = stop time - start time.
+
+### Timeline Serialization
+
+Actions are encoded as `code:type@time` entries joined by semicolons. The `parseActions()` function in `utils.js` deserializes this into structured objects. The `getGanttData()` function converts these into Gantt chart visualization data.
+
+### Debug Mode
+
+A `debugMode` state variable (`null`, `'quals'`, or `'playoffs'`) controls whether fetch functions hit live APIs or load from `/static/test-data/`. When active, CSV fetches redirect to test CSV files and TBA fetches go straight to local JSON fallbacks.
+
+### Context Menus
+
+Two interaction patterns for the same action:
+- **Desktop**: `contextmenu` event (right-click) opens a positioned menu
+- **Mobile**: `pointerdown` with a 600ms `setTimeout` triggers long-press behavior
+- Both pointer handlers filter `e.button !== 0` to prevent right-click from triggering left-click actions
+
+### Reactive Derivations
+
+The dashboard makes heavy use of Svelte's `$:` reactive statements. The playoff bracket simulation, for example, chains through multiple reactive blocks:
+
+```
+teamStatsMap → allianceSimulation → effectiveAlliances → bracketSimulation
+```
+
+Map-based reactivity uses an IIFE pattern to ensure Svelte tracks changes:
+```js
+$: bracketSimulation = ((overrides) => { /* ... */ })(playoffOverrides);
+```
+
+### LocalStorage Caching
+
+- **Dashboard**: Caches scouting data, team stats, colors, and details for 1 hour
+- **Assignments**: Caches generated assignments for 1 hour
+- Debug mode clears the cache on activation/deactivation
+
+## Component Responsibilities
+
+| Component | Props (Key) | Responsibility |
+|-----------|-------------|----------------|
+| `CoverageMap` | schedule, searchTerm, getScouterCount | Renders grid of match coverage cells |
+| `CoverageMapButton` | match, scouterCount, breakdown | Single coverage cell with hover tooltip |
+| `EventProgressMap` | schedule, matchPredictions, hoveredMatch | Quals progress grid with click/override handlers |
+| `PlayoffProgressMap` | bracketMatches, alliances, playoffOverrides | Playoff match grid with override support |
+| `RPCards` | alliance, predictions (with reasons) | 6 RP indicator cards with hover tooltips |
+| `SimulatorHeader` | alliance, teams, epa, opr | Alliance summary bar in simulator |
+| `SimulatorTeamCard` | team, stats, suggestions | Team input card with autocomplete |
+| `ContextMenu` | contextMenu, match | Right-click menu: "Load in Simulator" |
+| `OverrideContextMenu` | contextMenu, matchLabel, redLabel, blueLabel | Right-click menu: override/clear match prediction |
+
+## Utility Functions (`utils.js`)
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `getVal` | `(obj, key) → string` | Safe property accessor, returns `''` if missing |
+| `parseActions` | `(actionStr) → [{code, type, time}]` | Parse timeline string into sorted action array |
+| `getGanttData` | `(actionStr) → [{code, events}]` | Convert timeline into Gantt chart data structure |
+| `getActionColor` | `(code) → string` | Map action code to Tailwind CSS color class |
+
+---
+
+See [Data Format Reference](data-format-reference.md) for detailed schemas or [Setup & Deployment](setup-and-deployment.md) for configuration.

--- a/docs/competition-quickstart.md
+++ b/docs/competition-quickstart.md
@@ -1,0 +1,53 @@
+# Competition Quick Start
+
+> One-page reference for event day. Print this out and bring it to the competition.
+
+[Back to docs index](README.md)
+
+## URLs
+
+| Page | URL | Purpose |
+|------|-----|---------|
+| Scouting Form | `/scouting` | Fill out during each match |
+| Dashboard | `/scouting-dashboard` | Analyze data, run simulations |
+| Assignments | `/scouting-assignments` | Check your match assignments |
+
+## Scout Workflow (Per Match)
+
+1. Check your assignment on the Assignments page
+2. Open the Scouting Form on your device
+3. Enter your **initials**, **match number**, and **team number**
+4. Verify the team appears in the TBA auto-fetch (green highlight = correct)
+5. Select **starting position** on the field diagram
+6. Tap **START** when the match begins (or it auto-starts on first button press)
+7. **Hold buttons** while your robot performs each action — release when the action ends
+8. Fill out **endgame** fields (climb level, climb position, any issues)
+9. Rate **scoring effectiveness**, **feeding skill**, and **defense skill** (0-5 each)
+10. Write a **comment** (required — we read every one)
+11. Tap **SUBMIT**
+
+> [!IMPORTANT]
+> Hold-to-time buttons track *duration*. Press and hold for as long as the robot performs the action. Don't tap — hold.
+
+## Dashboard Modes
+
+| Mode | Color | What It Shows | When to Use |
+|------|-------|---------------|-------------|
+| Leaderboard | Green | EPA/OPR rankings for all teams | Default view between matches |
+| Simulator | Blue | 3v3 alliance comparison | Before a specific match |
+| Selection | Orange | EPA-ranked pick list | During alliance selection |
+| Defense | Red | Defensive effectiveness ratings | Evaluating defenders |
+| Overview | Purple | Single-team deep dive | Pre-match strategy prep |
+| Pit | White | Pit scouting data and robot photos | Walk-around / pit visits |
+| Scout Lead | Yellow | Missing scouting coverage | Between matches, filling gaps |
+
+## Quick Tips
+
+- **Right-click** (desktop) or **long-press** (mobile) on match cards to override predictions
+- **Click any match** in the progress maps to load it into the simulator
+- Use **Quick Links** menu for fast access to TBA, Statbotics, and forms
+- **Debug mode** (Quick Links menu) loads test data for practice — don't use at competition
+
+## If Something Breaks
+
+See [Troubleshooting](troubleshooting.md) for common problems and fixes.

--- a/docs/data-format-reference.md
+++ b/docs/data-format-reference.md
@@ -1,0 +1,227 @@
+# Data Format Reference
+
+> Schemas for CSV data, timeline encoding, and API response shapes used by the scouting system.
+
+[Back to docs index](README.md)
+
+## Scouting CSV Columns
+
+These columns appear in the Google Sheet that receives scouting form responses. The dashboard fetches this sheet as CSV.
+
+| Column | Form Field ID | Type | Example |
+|--------|--------------|------|---------|
+| Scouter Initials | `entry.55361842` | text | `ABC` |
+| Match # | `entry.528540297` | number | `12` |
+| Team # | `entry.1130076361` | number | `1757` |
+| Starting position? | `entry.236449401` | enum | `OT` |
+| No Show | `entry.65205079` | checkbox | `no show` |
+| Timeline | `entry.2000596765` | serialized | see [Timeline Format](#timeline-format) |
+| Auto Climb Result | `entry.287801541` | enum | `No`, `Out`, `Mid`, `Dep`, `F` |
+| Alliance won auto? | `entry.901735072` | checkbox | `true` |
+| Defended by opponent? | `entry.942649623` | checkbox | `true` |
+| Climb Level | `entry.477247024` | enum | `No`, `L1`, `L2`, `L3`, `F` |
+| Climb Position | `entry.1268059521` | enum | `No`, `Out`, `Mid`, `Dep` |
+| Mech Issue | `entry.676569017` | checkbox | `true` |
+| Died | `entry.1940984634` | checkbox | `true` |
+| Tipped | `entry.1961795439` | checkbox | `true` |
+| Scoring effectiveness? | `entry.975098497` | 0-5 | `4` |
+| Scored How? | `entry.1864643366` | enum | `While driving` |
+| Scoring Locations | `entry.728375142` | multi | `1`, `2`, `3` |
+| Feeding Skill | `entry.2132357592` | 0-5 | `3` |
+| Passed How? | `entry.788387708` | enum | `While stationary` |
+| Defense Skill | `entry.1384370540` | 0-5 | `2` |
+| Card | `entry.1816355809` | enum | `No Card`, `Yellow`, `Red` |
+| Comments | `entry.568874806` | text | free text |
+| GambleScout prediction | `entry.908293542` | enum | `b` or `r` |
+
+> [!NOTE]
+> The CSV uses a 2-row header (row 1 = Google Form internal labels, row 2 = column headers). The dashboard's CSV parser skips the first 2 rows using `parseCSV(text, 2)`.
+
+## Pit Scouting CSV Columns
+
+| Column | Type | Example |
+|--------|------|---------|
+| Team number | number | `1757` |
+| Drive Train Type | text | `Swerve` |
+| Frame dimensions | text | `28x28` |
+| Weight | text | `120 lbs` |
+| Under trench? | text | `Yes` |
+| Over bump? | text | `Yes` |
+| Drive Coach | text | `Jane Smith` |
+| Team Friendliness | text | `Very friendly` |
+| Best Auto | text | `3 piece auto` |
+| Bot pic | URL | Google Drive image URL |
+
+The pit CSV uses a 1-row header: `parseCSV(text, 1)`.
+
+## Timeline Format
+
+Actions during a match are serialized as a semicolon-delimited string of entries.
+
+### Entry Format
+
+```
+{code}:{type}@{time}
+```
+
+| Component | Values | Description |
+|-----------|--------|-------------|
+| `code` | Action code string | Which action was performed |
+| `type` | `start`, `stop`, `point` | Start/stop of a held action, or an instant event |
+| `time` | Integer (seconds) | Seconds elapsed since the match timer started |
+
+### Example
+
+```
+auto_score:start@3;auto_score:stop@8;tele_fuel:point@45;tele_def:start@60;tele_def:stop@90
+```
+
+This means:
+- Scoring from 3s to 8s during auto (5-second action)
+- Fuel scored at 45s during teleop (instant)
+- Defense played from 60s to 90s during teleop (30-second action)
+
+### Action Codes
+
+#### Autonomous (Hold-to-Time)
+
+| Code | Action |
+|------|--------|
+| `auto_score` | Scoring game pieces |
+| `auto_pass` | Passing to alliance partners |
+| `auto_outpost` | Collecting from outpost |
+| `auto_depot` | Collecting from depot |
+| `auto_ground` | Collecting from ground |
+| `auto_climb` | Climbing |
+| `auto_trench` | Traversing the trench |
+| `auto_faff` | Wasting time (stuck, confused) |
+
+#### Teleop (Hold-to-Time)
+
+| Code | Action |
+|------|--------|
+| `tele_score` | Scoring game pieces |
+| `tele_coll` | Collecting game pieces |
+| `tele_pass` | Passing to alliance partners |
+| `tele_faff` | Wasting time |
+| `tele_def` | Playing defense |
+| `tele_climb` | Climbing |
+| `tele_alliance` | In alliance zone |
+| `tele_neutral` | In neutral zone |
+| `tele_opponent` | In opponent zone |
+
+#### Instant Actions (Tap Counters)
+
+| Code | Action |
+|------|--------|
+| `auto_fuel` | Fuel scored during auto |
+| `tele_fuel` | Fuel scored during teleop |
+| `tele_fed` | Fuel fed to alliance partner |
+
+### Action Color Mapping
+
+Used by `getActionColor()` in `utils.js` for Gantt chart visualization:
+
+| Code Contains | Color |
+|---------------|-------|
+| `score` | Green (`bg-green-500`) |
+| `coll`, `outpost`, `depot`, `ground` | Blue (`bg-blue-500`) |
+| `pass` | Orange (`bg-orange-500`) |
+| `climb` | Purple (`bg-purple-500`) |
+| `die` | Red (`bg-red-500`) |
+| `card` | Yellow (`bg-yellow-500`) |
+| `tip` | Pink (`bg-pink-500`) |
+| Other | Gray (`bg-zinc-500`) |
+
+## Starting Position Codes
+
+| Code | Field Position |
+|------|---------------|
+| `OT` | Outpost Trench |
+| `OBFT` | Outpost Bump Favoring Trench |
+| `OBFH` | Outpost Bump Favoring Hub |
+| `H` | Hub |
+| `DBFH` | Depot Bump Favoring Hub |
+| `DBFT` | Depot Bump Favoring Trench |
+| `DT` | Depot Trench |
+| `NS` | No position / no show |
+
+## Climb Enums
+
+### Auto Climb Result
+
+| Value | Meaning |
+|-------|---------|
+| `No` | No climb attempted |
+| `Out` | Output side |
+| `Mid` | Middle |
+| `Dep` | Depot side |
+| `F` | Failed climb |
+
+### Endgame Climb Level
+
+| Value | Meaning |
+|-------|---------|
+| `No` | No climb |
+| `L1` | Level 1 |
+| `L2` | Level 2 |
+| `L3` | Level 3 |
+| `F` | Failed climb |
+
+### Endgame Climb Position
+
+Same as Auto Climb Result: `No`, `Out`, `Mid`, `Dep`.
+
+## Scoring Location Codes
+
+| Value | Location |
+|-------|----------|
+| `1` | Outpost Trench |
+| `2` | Outpost |
+| `3` | Hub |
+| `4` | Ladder |
+| `5` | Depot |
+| `6` | Depot Trench |
+
+## Win Probability Formula
+
+The dashboard calculates win probability from EPA difference:
+
+```
+winProb = 1 / (1 + 10^((-5/8 * scoreDiff) / score_sd))
+```
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `scoreDiff` | Red EPA sum - Blue EPA sum | EPA advantage of red alliance |
+| `score_sd` | Statbotics year stats | Standard deviation of scores (default: ~20) |
+
+Result: probability from 0 to 1 that the red alliance wins.
+
+## RP Prediction Thresholds
+
+| Metric | Lit (Likely) | Contention (Possible) | Muted (Unlikely) |
+|--------|-------------|----------------------|-------------------|
+| RP sum (rp1/rp2/rp3) | > 1.0 | > 0.8 | <= 0.8 |
+| Win probability | > 62.5% | 37.5% - 62.5% | < 37.5% |
+
+RP sum = sum of individual team EPA RP values for the 3 alliance teams.
+
+## Test Data Files
+
+Located in `/static/test-data/`. Used by [debug mode](scouting-dashboard.md#debug-mode) and as fallback when API calls fail.
+
+| File | Format | Contents |
+|------|--------|----------|
+| `scouting.csv` | CSV | 180 mock scouting entries |
+| `pit.csv` | CSV | 32 teams of mock pit data |
+| `schedule.json` | JSON (TBA format) | 60 qualification matches |
+| `playoff-schedule.json` | JSON (TBA format) | 14 playoff matches (8 played, 6 unplayed) |
+| `rankings.json` | JSON (TBA format) | 32 team rankings |
+| `alliances.json` | JSON (TBA format) | 8 alliance selections |
+| `oprs.json` | JSON (TBA format) | OPR values for all teams |
+| `teams.json` | JSON | Array of team keys (`["frc61", "frc78", ...]`) |
+
+---
+
+See [Architecture](architecture.md) for how these formats are used in the codebase.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1757 Scouting System Docs</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown-dark.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    body {
+      background: #0d1117;
+      color: #e6edf3;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      margin: 0;
+      display: flex;
+      min-height: 100vh;
+    }
+    nav {
+      width: 260px;
+      min-width: 260px;
+      background: #161b22;
+      border-right: 1px solid #30363d;
+      padding: 20px;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      box-sizing: border-box;
+    }
+    nav h2 {
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 1.5px;
+      color: #8b949e;
+      margin: 20px 0 8px;
+    }
+    nav h2:first-child { margin-top: 0; }
+    nav a {
+      display: block;
+      padding: 6px 10px;
+      margin: 2px 0;
+      color: #58a6ff;
+      text-decoration: none;
+      font-size: 14px;
+      border-radius: 6px;
+      transition: background 0.15s;
+    }
+    nav a:hover { background: #1f2937; }
+    nav a.active { background: #1f6feb33; color: #79c0ff; font-weight: 600; }
+    main {
+      flex: 1;
+      max-width: 900px;
+      padding: 40px 50px;
+    }
+    .markdown-body {
+      background: transparent;
+    }
+    .markdown-body table { display: table; width: 100%; }
+    .markdown-body blockquote {
+      border-left-color: #3b82f6;
+      color: #8b949e;
+    }
+    /* GitHub-style callouts */
+    .markdown-body blockquote p:first-child {
+      font-weight: normal;
+    }
+    @media (max-width: 768px) {
+      body { flex-direction: column; }
+      nav {
+        width: 100%;
+        min-width: 100%;
+        height: auto;
+        position: static;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        padding: 12px;
+      }
+      nav h2 { width: 100%; margin: 8px 0 4px; }
+      nav a { display: inline-block; }
+      main { padding: 20px; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <h2>Scouts & Strategy</h2>
+    <a href="#" data-page="competition-quickstart">Competition Quick Start</a>
+    <a href="#" data-page="scouting-form">Scouting Form Guide</a>
+    <a href="#" data-page="scouting-dashboard">Dashboard Guide</a>
+    <a href="#" data-page="scout-assignments">Scout Assignments</a>
+    <h2>Developers</h2>
+    <a href="#" data-page="setup-and-deployment">Setup & Deployment</a>
+    <a href="#" data-page="architecture">Architecture</a>
+    <a href="#" data-page="data-format-reference">Data Format Reference</a>
+    <h2>Everyone</h2>
+    <a href="#" data-page="troubleshooting">Troubleshooting</a>
+  </nav>
+  <main>
+    <article id="content" class="markdown-body"></article>
+  </main>
+  <script>
+    const contentEl = document.getElementById('content');
+    const links = document.querySelectorAll('nav a[data-page]');
+
+    async function loadPage(page) {
+      try {
+        const res = await fetch(page + '.md');
+        if (!res.ok) throw new Error('Not found');
+        let md = await res.text();
+        // Convert GitHub callouts to styled HTML
+        md = md.replace(/> \[!(TIP|IMPORTANT|WARNING|NOTE)\]\n>/g, (_, type) => {
+          const colors = { TIP: '#3fb950', IMPORTANT: '#a371f7', WARNING: '#d29922', NOTE: '#58a6ff' };
+          const icons = { TIP: '💡', IMPORTANT: '❗', WARNING: '⚠️', NOTE: 'ℹ️' };
+          return `> ${icons[type]} **${type}**\n>`;
+        });
+        contentEl.innerHTML = marked.parse(md);
+        // Update active link
+        links.forEach(l => l.classList.toggle('active', l.dataset.page === page));
+        // Update URL hash
+        window.location.hash = page;
+        // Scroll to top
+        window.scrollTo(0, 0);
+      } catch (e) {
+        contentEl.innerHTML = '<h1>Page not found</h1><p>Could not load ' + page + '.md</p>';
+      }
+    }
+
+    // Handle nav clicks
+    links.forEach(link => {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        loadPage(link.dataset.page);
+      });
+    });
+
+    // Handle in-page markdown links
+    contentEl.addEventListener('click', (e) => {
+      const a = e.target.closest('a');
+      if (!a) return;
+      const href = a.getAttribute('href');
+      if (href && href.endsWith('.md')) {
+        e.preventDefault();
+        const page = href.replace('.md', '').replace('./', '');
+        if (page === 'README') {
+          loadPage('competition-quickstart');
+        } else {
+          loadPage(page);
+        }
+      }
+    });
+
+    // Load initial page from hash or default
+    const initialPage = window.location.hash.slice(1) || 'competition-quickstart';
+    loadPage(initialPage);
+  </script>
+</body>
+</html>

--- a/docs/scout-assignments.md
+++ b/docs/scout-assignments.md
@@ -1,0 +1,82 @@
+# Scout Assignments
+
+> Automatically assign scouts to teams based on availability windows and workload balance.
+
+[Back to docs index](README.md)
+
+## Setup Requirements
+
+Before assignments can be generated, you need:
+
+1. **Scouts CSV** — A Google Sheet with scout names and availability, published as CSV
+2. **TBA API key** — Set as `VITE_TBA_KEY` environment variable
+3. **Event key** — Set as `VITE_EVENT_KEY` (defaults to `2026rikin`)
+4. **Scouts CSV URL** — Set as `VITE_SCOUTS_CSV_URL`
+
+### Scouts CSV Format
+
+The Google Sheet must have these columns:
+
+| Column | Example | Description |
+|--------|---------|-------------|
+| Scout Name | Jane Smith | Full name of the scout |
+| Start avail day 1 | 4/4/2026 8:00:00 | When the scout is available on day 1 |
+| End avail day 1 | 4/4/2026 17:00:00 | When the scout leaves on day 1 |
+| Start avail day 2 | 4/5/2026 8:00:00 | When the scout is available on day 2 |
+| End avail day 2 | 4/5/2026 17:00:00 | When the scout leaves on day 2 |
+
+Publish the sheet: **File > Share > Publish to web > CSV format**.
+
+## How Assignment Works
+
+The algorithm assigns scouts to matches in batches of 5, balancing workload:
+
+1. **Batching** — Matches are grouped into batches of 5 to give scouts breaks between assignments
+2. **Availability check** — Only scouts available during the match time window are considered
+3. **Load balancing** — Scouts with the largest gap since their last assignment are picked first
+4. **Tiebreaking** — If gaps are equal, the scout with fewer total assignments is chosen
+5. **No duplicates** — A scout is never assigned twice in the same batch
+
+Each match needs 6 scouts (one per robot: 3 red alliance + 3 blue alliance).
+
+## Using the Assignments Page
+
+Navigate to `/scouting-assignments`.
+
+### Scouts Panel (Left)
+
+- Lists all scouts with their availability windows
+- Shows total assignment count per scout
+- Click a scout's name to view their personal timeline
+
+### Assignments Panel (Right)
+
+- **Scout Timeline** — Shows selected scout's matches with break durations between them
+- **All Assignments** — Grid showing every match with assigned scouts, separated by alliance
+- Match times shown in color: green (actual), blue (predicted), gray (scheduled)
+
+### Match Time Display
+
+| Color | Meaning |
+|-------|---------|
+| Green | Actual match time from TBA |
+| Blue | Predicted time based on schedule |
+| Gray | Scheduled time (no prediction available) |
+
+Day separators and end-of-day markers help scouts plan their time.
+
+## Caching
+
+Assignments are cached in your browser's localStorage for **1 hour**. This avoids regenerating assignments on every page load.
+
+- The cache age is displayed on the page
+- Click **Refresh** to force regeneration
+- Clear browser cache manually: Developer Tools > Application > Local Storage > delete `scouting_assignments_cache`
+
+## Coordinating with the Dashboard
+
+Use **Scout Lead mode** on the [Dashboard](scouting-dashboard.md) to check for coverage gaps. If a match is missing scouting data, check whether the assigned scout was unavailable or reassign manually.
+
+---
+
+See [Troubleshooting](troubleshooting.md) if assignments aren't loading.

--- a/docs/scouting-dashboard.md
+++ b/docs/scouting-dashboard.md
@@ -1,0 +1,204 @@
+# Scouting Dashboard Guide
+
+> Analyze scouting data, predict match outcomes, and prepare for alliance selection. The dashboard pulls data from multiple sources and provides seven analysis modes.
+
+[Back to docs index](README.md)
+
+## Getting Started
+
+Navigate to `/scouting-dashboard`. The dashboard automatically loads data from:
+
+- **Google Sheets** — Scouting and pit data submitted through the forms
+- **The Blue Alliance** — Match schedule, rankings, OPRs, and alliance selections
+- **Statbotics** — EPA (Expected Points Added) ratings and match predictions
+- **FRC Colors** — Team color theming
+
+Loading indicators show progress for each data source. If a source fails, the dashboard continues with available data.
+
+## Dashboard Modes
+
+Toggle between modes using the buttons at the top. Only one mode is active at a time.
+
+### Leaderboard (Default)
+
+The default view when you open the dashboard.
+
+- All teams ranked by EPA from Statbotics
+- Sortable columns for EPA, OPR, and scouting averages
+- Click any team row to expand match-by-match scouting detail
+- Use the search bar to filter by team number
+
+### Simulator
+
+Compare two alliances in a 3v3 simulation.
+
+- Enter team numbers in the three red and three blue slots
+- View aggregated EPA, OPR, and win probability
+- **RP Prediction Cards** show Ranking Point likelihood for each alliance (Energized, Supercharged, Traversal, Win)
+- Hover over any RP card to see the per-team EPA breakdown and threshold reasoning
+- Performance charts show trends for each team
+
+**Loading matches into the simulator:**
+- Click any match in the Event Progress or Playoff Progress maps
+- Right-click a match in the Coverage Map and select "Load in Simulator"
+- Long-press a match on mobile to load it
+
+### Alliance Selection Mode
+
+EPA-ranked pick list for alliance selection.
+
+- Teams ranked by EPA with optimal alliance pairings
+- Simulates the 8-alliance snake draft order
+- Click teams to cross them off as they're picked by other alliances
+- Updates in real time as the draft progresses
+
+### Defense Mode
+
+Defensive effectiveness analysis.
+
+- Teams ranked by defense skill ratings from scouting data
+- Filters for defense-specific metrics
+- Helps identify strong defenders for alliance strategy
+
+### Overview Mode
+
+Single-team deep dive.
+
+- Select a team to view all their match data in one place
+- **Performance trend charts** — Line graphs across matches for scoring, feeding, and defense
+- **Action timelines** — Gantt-style visualization of what the robot did during each match
+- **Starting position distribution** — Where the team typically starts
+- **Pit scouting data** — Robot specs and photos (if available)
+- **Consistency metrics** — Early-game vs. late-game effectiveness
+
+### Pit Mode
+
+Pit scouting data display.
+
+- Shows pit scouting responses for each team
+- Drive train type, frame dimensions, weight, and capabilities
+- Image viewer for robot photos with pinch-to-zoom on mobile
+
+### Scout Lead Mode
+
+Assignment management and coverage tracking.
+
+- Shows matches with missing scouting coverage
+- Lists which teams still need to be scouted per match
+- Use between matches to identify and fill coverage gaps
+- Cross-reference with the Coverage Map for a visual overview
+
+## Visual Components
+
+### Coverage Map
+
+A grid showing which team/match combinations have been scouted.
+
+- **Green** = Fully scouted (all 6 robots in the match have data)
+- **Partial** = Some robots scouted, some missing
+- **Empty** = No scouting data for this match
+- Right-click any match to load it into the simulator
+
+### Event Progress Map (Quals)
+
+A color-coded grid of all qualification matches showing predictions and results.
+
+| Color | Meaning |
+|-------|---------|
+| Muted red | Red alliance won (actual result) |
+| Muted blue | Blue alliance won (actual result) |
+| Bright red | Red predicted to win (unplayed) |
+| Bright blue | Blue predicted to win (unplayed) |
+| Gray | Toss-up (close prediction) |
+| Yellow ring | Manual override applied |
+
+- Hover over any match for a tooltip showing teams and prediction details
+- Click to load the match into the simulator
+
+### Playoff Progress Map
+
+A compact grid of all playoff bracket matches (M1-M14).
+
+- Same color scheme as the Event Progress Map
+- Predictions flow through the double-elimination bracket
+- Override any unplayed match to see how results cascade
+
+### RP Prediction Cards
+
+Six cards per alliance in the simulator showing Ranking Point predictions:
+
+| Card | RP Type | Threshold |
+|------|---------|-----------|
+| Energized | RP1 | Sum of team EPA RP1 values |
+| Supercharged | RP2 | Sum of team EPA RP2 values |
+| Traversal | RP3 | Sum of team EPA RP3 values |
+| Win (x3) | Win bonus | EPA-based win probability |
+
+**Card states:**
+- **Lit** (bright color) — Likely (RP sum > 1.0 or win prob > 62.5%)
+- **Contention** (dim color) — Possible (RP sum > 0.8 or win prob 37.5-62.5%)
+- **Muted** (gray) — Unlikely (RP sum <= 0.8 or win prob < 37.5%)
+
+Hover over any card for the detailed breakdown.
+
+### Playoff Bracket
+
+Full double-elimination bracket display showing all 14 matches:
+
+- **Upper Bracket**: Round 1 (M1-M4), Round 2 (M5-M6), Upper Final (M7)
+- **Lower Bracket**: Lower Round 2 (M8-M9), Lower Round 3 (M10-M11), Lower Round 4 (M12), Lower Final (M13)
+- **Grand Finals**: M14 (+ optional M15 tiebreaker)
+
+Click any match to load those alliance teams into the simulator.
+
+## What-If Overrides
+
+Override any match prediction to explore "what-if" scenarios. Overrides cascade through the bracket and ranking predictions.
+
+**Desktop:** Right-click on an unplayed match card → select "Override Red", "Override Blue", or "Clear Override"
+
+**Mobile:** Long-press (hold ~1 second) on an unplayed match card to cycle through override options
+
+**Clearing overrides:**
+- Right-click → "Clear Override" clears a single match
+- "Clear Overrides" button (next to section headers) clears all overrides in that section
+
+> [!NOTE]
+> For playoff matches, the override menu shows "Override Alliance {N}" instead of red/blue, since playoff alliances don't correspond to a fixed color.
+
+## Quick Links Menu
+
+Access external tools and debug options from the Quick Links dropdown:
+
+| Link | Destination |
+|------|-------------|
+| Pit Scouting Form | Google Form for pit data (if configured) |
+| Scouting Form | `/scouting` form page |
+| Scouting Assignments | `/scouting-assignments` page |
+| TBA Event | The Blue Alliance event page |
+| Statbotics | Statbotics event page |
+| Help Docs | This documentation |
+
+### Debug Mode
+
+> [!WARNING]
+> Debug mode loads fake test data. Don't activate this during a real competition.
+
+Access via Quick Links:
+
+- **Debug — Quals**: Loads test qualification data. Playoffs run in pure prediction mode (no actual alliances).
+- **Debug — Playoffs**: Loads all test data including playoff results and alliance selections.
+- **Run Live Dashboard**: Returns to live API data (only shown when debug mode is active).
+
+A yellow warning banner appears at the top of the dashboard when debug mode is active.
+
+## Other Features
+
+- **Fullscreen mode** — Toggle with the fullscreen button in the header
+- **Team search** — Type a team number to filter all views
+- **Data caching** — Data is cached in your browser for 1 hour. Hard refresh (Ctrl+Shift+R) to force a reload.
+- **Match videos** — YouTube match videos can be embedded when available
+
+---
+
+See [Troubleshooting](troubleshooting.md) if data isn't loading or features aren't working.

--- a/docs/scouting-form.md
+++ b/docs/scouting-form.md
@@ -1,0 +1,218 @@
+# Scouting Form Guide
+
+> Collect match data by holding buttons while robots perform actions. The form captures timing data, performance ratings, and observer comments.
+
+[Back to docs index](README.md)
+
+## Before the Match
+
+### Pre-Match Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Scouter Initials | Yes | Your initials (identifies who scouted) |
+| Match Number | Yes | The qualification match number |
+| Team Number | Yes | The team you're assigned to watch |
+| Starting Position | Yes | Where the robot starts on the field |
+| No Show | No | Check if the robot doesn't appear on the field |
+
+### TBA Auto-Fetch
+
+When you enter a **match number**, the form automatically fetches alliance data from The Blue Alliance:
+
+- Displays red and blue alliance team numbers (R1, R2, R3 / B1, B2, B3)
+- Validates your team number is in the match (green = correct, red = wrong match)
+- Loads Statbotics win predictions for GambleScout
+
+### Starting Positions
+
+| Code | Position |
+|------|----------|
+| OT | Outpost Trench |
+| OBFT | Outpost Bump Favoring Trench |
+| OBFH | Outpost Bump Favoring Hub |
+| H | Hub |
+| DBFH | Depot Bump Favoring Hub |
+| DBFT | Depot Bump Favoring Trench |
+| DT | Depot Trench |
+| NS | No position / no show |
+
+### GambleScout (Optional)
+
+A fun prediction game that appears after match data loads. Predict which alliance wins — you can only gain points, never lose them. Point values are weighted by how unlikely your pick is (betting on the underdog pays more).
+
+## During the Match: Autonomous
+
+> [!IMPORTANT]
+> **Hold-to-time buttons**: Press and hold while the robot performs the action. Release when the action ends. The duration is recorded automatically.
+
+### Autonomous Action Buttons
+
+| Button | Code | What to Track |
+|--------|------|---------------|
+| SCORING | `auto_score` | Robot is actively scoring game pieces |
+| PASSING | `auto_pass` | Robot is passing game pieces to alliance partners |
+| OUTPOST COLL | `auto_outpost` | Robot is collecting from the outpost |
+| DEPOT COLL | `auto_depot` | Robot is collecting from the depot |
+| GROUND COLL | `auto_ground` | Robot is collecting from the ground |
+| CLIMBING | `auto_climb` | Robot is attempting to climb |
+| TRENCH | `auto_trench` | Robot is traversing the trench |
+| FAFFING | `auto_faff` | Robot is wasting time (stuck, confused, etc.) |
+
+### Auto Climb Result
+
+After autonomous ends, select the climb result:
+
+| Option | Meaning |
+|--------|---------|
+| No | Did not attempt climb |
+| Output Side | Climbed on output side |
+| Middle | Climbed in the middle |
+| Depot Side | Climbed on depot side |
+| Failed Climb | Attempted but failed |
+
+## During the Match: Teleop
+
+Same hold-to-time pattern with teleop-specific actions:
+
+### Teleop Action Buttons
+
+| Button | Code | What to Track |
+|--------|------|---------------|
+| SCORING | `tele_score` | Robot is actively scoring |
+| COLLECTING | `tele_coll` | Robot is collecting game pieces |
+| PASSING | `tele_pass` | Robot is passing to partners |
+| FAFFING | `tele_faff` | Robot is wasting time |
+| DEFENSE | `tele_def` | Robot is playing defense |
+| CLIMBING | `tele_climb` | Robot is climbing |
+| ALLIANCE ZONE | `tele_alliance` | Robot is in the alliance zone |
+| NEUTRAL ZONE | `tele_neutral` | Robot is in the neutral zone |
+| OPPONENT ZONE | `tele_opponent` | Robot is in the opponent zone |
+
+### Teleop Counters (Tap to Increment)
+
+| Button | Code | What to Track |
+|--------|------|---------------|
+| Fuel Scored | `tele_fuel` | Each fuel piece scored (tap once per piece) |
+| Fuel Fed | `tele_fed` | Each fuel piece fed to partner |
+
+### Teleop Checkboxes
+
+- **Alliance won auto?** — Check if your alliance won the autonomous period
+- **Defended by opponent?** — Check if an opponent robot played defense on your team
+
+## After the Match: Endgame
+
+### Climb Level
+
+| Option | Meaning |
+|--------|---------|
+| No Climb | Did not climb |
+| L1 | Level 1 climb |
+| L2 | Level 2 climb |
+| L3 | Level 3 climb |
+| Failed Climb | Attempted but failed |
+
+### Climb Position
+
+| Option | Meaning |
+|--------|---------|
+| No Climb | Did not climb |
+| Output Side | Climbed on output side |
+| Middle | Climbed in the middle |
+| Depot Side | Climbed on depot side |
+
+### Issue Checkboxes
+
+- **Mech Issue** — Robot had a mechanical problem during the match
+- **Died** — Robot stopped functioning entirely
+- **Tipped** — Robot tipped over during the match
+
+## After the Match: Ratings
+
+### Scoring Effectiveness (0-5)
+
+Rate how effectively the robot scored game pieces. Use the slider.
+
+- **0** = Did not score at all
+- **5** = Extremely effective scorer
+
+### Scored How?
+
+| Option | Meaning |
+|--------|---------|
+| While driving | Scored while in motion |
+| While stationary | Scored from a fixed position |
+| Both | Used both methods |
+| No scoring | Did not score |
+
+### Scoring Locations
+
+Check all field zones where the robot scored (checkboxes, multiple allowed):
+
+1. Outpost Trench
+2. Outpost
+3. Hub
+4. Ladder
+5. Depot
+6. Depot Trench
+
+### Feeding Skill (0-5)
+
+Rate how effectively the robot passed/fed game pieces to alliance partners.
+
+### Passed How?
+
+Same options as "Scored How?" — driving, stationary, both, or no passing.
+
+### Defense Skill (0-5)
+
+Rate how effectively the robot played defense (0 = no defense played).
+
+### Card
+
+| Option | Meaning |
+|--------|---------|
+| No Card | No penalty cards received |
+| Yellow | Yellow card issued |
+| Red | Red card issued |
+
+### Comments (Required)
+
+Write observations about the robot's performance. These are read by the strategy team during alliance selection.
+
+> [!TIP]
+> Good comments mention specific things: "Fast cycle time but struggled with ground pickup" is more useful than "Good robot."
+
+## Match Timer
+
+- The timer appears as a sticky header showing elapsed time (MM:SS)
+- Press **START** to begin, or it auto-starts on your first button press
+- Press **STOP** to pause, then **START** to resume
+- Press **RESET** to clear all data and start over
+
+## How Timeline Data Works
+
+Every button press creates a timeline entry stored in the format `code:type@time`:
+
+- `code` — The action code (e.g., `auto_score`, `tele_def`)
+- `type` — Either `start` (button pressed), `stop` (button released), or `point` (instant tap)
+- `time` — Seconds elapsed since the timer started
+
+**Example**: `auto_score:start@3;auto_score:stop@8;tele_fuel:point@45`
+
+This means: scoring started at 3 seconds, stopped at 8 seconds (5-second scoring action), then a fuel point was scored at 45 seconds.
+
+The timeline is submitted as a hidden form field and powers the Gantt chart visualizations on the dashboard.
+
+## Tips
+
+- **Hold buttons for the full duration** of the action, not just a tap
+- If you miss something, the timer keeps running — just pick up where you left off
+- Comments matter more than you think — the strategy team reads every one
+- If the robot dies early, mark "Died" and note it in comments
+- Don't worry about being perfect — some data is better than no data
+
+---
+
+See [Troubleshooting](troubleshooting.md) if the form isn't working properly.

--- a/docs/setup-and-deployment.md
+++ b/docs/setup-and-deployment.md
@@ -1,0 +1,124 @@
+# Setup & Deployment
+
+> Get the scouting system running locally or deploy to production.
+
+[Back to docs index](README.md)
+
+## Prerequisites
+
+- **Node.js 18** or later
+- **npm** (included with Node.js)
+- **TBA API key** — [Register at thebluealliance.com](https://www.thebluealliance.com/account)
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+The dev server starts at `http://localhost:5173` (or next available port).
+
+## Environment Variables
+
+Create a `.env` file in the project root with these variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VITE_TBA_KEY` | Yes | — | The Blue Alliance API key |
+| `VITE_EVENT_KEY` | No | `2026rikin` | TBA event key for the competition |
+| `VITE_SCOUTING_CSV_URL` | Yes* | — | Published Google Sheets CSV URL for match scouting data |
+| `VITE_PIT_CSV_URL` | No | — | Published Google Sheets CSV URL for pit scouting data |
+| `VITE_SCOUTS_CSV_URL` | No | — | Published Google Sheets CSV URL for scout roster/availability |
+| `VITE_FILTER_TIME` | No | — | ISO timestamp to filter scouting data (e.g., `2026-03-28T09:00:00`) |
+| `VITE_PIT_SCOUTING_FORM_URL` | No | — | Google Form URL for pit scouting submissions |
+
+*Not required if using [debug mode](scouting-dashboard.md#debug-mode), which loads from test data.
+
+> [!IMPORTANT]
+> All variables must be prefixed with `VITE_` to be accessible in client-side code. Restart the dev server after changing `.env`.
+
+### Example `.env`
+
+```env
+VITE_TBA_KEY=your_tba_api_key_here
+VITE_EVENT_KEY=2026rikin
+VITE_SCOUTING_CSV_URL=https://docs.google.com/spreadsheets/d/SHEET_ID/export?format=csv&gid=0
+VITE_PIT_CSV_URL=https://docs.google.com/spreadsheets/d/SHEET_ID/export?format=csv&gid=123456
+VITE_SCOUTS_CSV_URL=https://docs.google.com/spreadsheets/d/SHEET_ID/export?format=csv&gid=789
+VITE_PIT_SCOUTING_FORM_URL=https://docs.google.com/forms/d/e/FORM_ID/viewform
+```
+
+## Google Sheets Setup
+
+The scouting form submits data to a Google Form, which populates a Google Sheet. To connect the dashboard:
+
+1. Open the Google Sheet that receives scouting form responses
+2. Go to **File > Share > Publish to web**
+3. Select the correct sheet tab and choose **CSV** format
+4. Click **Publish** and copy the URL
+5. Set `VITE_SCOUTING_CSV_URL` to this URL
+
+Repeat for pit scouting data (`VITE_PIT_CSV_URL`) and scout roster (`VITE_SCOUTS_CSV_URL`).
+
+> [!NOTE]
+> The published CSV URL auto-updates when new form responses come in. No manual re-publishing needed.
+
+## Building
+
+```bash
+npm run build
+npm run preview    # verify the production build locally
+```
+
+The build outputs to `./build` using SvelteKit's static adapter with a `404.html` fallback for client-side routing.
+
+## Deployment
+
+### Automatic (GitHub Actions)
+
+Push to the `next` branch to trigger automatic deployment to GitHub Pages.
+
+The workflow (`.github/workflows/AutoDeploy.yml`):
+1. Checks out the code
+2. Sets up Node.js 18
+3. Runs `npm ci` and `npm run build` with environment variables from GitHub Secrets
+4. Deploys the `build/` directory to GitHub Pages
+
+### GitHub Secrets
+
+These must be configured in the repository settings (Settings > Secrets and variables > Actions):
+
+| Secret | Maps To |
+|--------|---------|
+| `TBA_API_KEY` | `VITE_TBA_KEY` |
+| `EVENT_KEY` | `VITE_EVENT_KEY` |
+| `SCOUTING_CSV_URL` | `VITE_SCOUTING_CSV_URL` |
+| `PIT_CSV_URL` | `VITE_PIT_CSV_URL` |
+| `PIT_SCOUTING_FORM_URL` | `VITE_PIT_SCOUTING_FORM_URL` |
+| `SCOUTS_CSV_URL` | `VITE_SCOUTS_CSV_URL` |
+
+### Manual Deployment
+
+```bash
+npm run build
+npm run deploy    # pushes build/ to the deployment branch via gh-pages
+```
+
+## Updating for a New Season
+
+When preparing for a new competition season:
+
+- [ ] Update `VITE_EVENT_KEY` to the new event key (e.g., `2027txhou`)
+- [ ] Create new Google Forms and Sheets for the new season's game
+- [ ] Update scouting form fields if game mechanics change
+  - Form field `entry.*` IDs map to Google Form question IDs
+  - Action button codes (`auto_score`, `tele_def`, etc.) should match new game actions
+- [ ] Update starting position options in the form's `posMap` and select elements
+- [ ] Update test data files in `/static/test-data/` to match new game format
+- [ ] Update environment variables and GitHub Secrets
+- [ ] Verify the dashboard's RP prediction labels match the new season's ranking points
+
+---
+
+See [Architecture](architecture.md) for codebase details or [Troubleshooting](troubleshooting.md) for common issues.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,139 @@
+# Troubleshooting
+
+> Common problems and how to fix them at a competition.
+
+[Back to docs index](README.md)
+
+## Scouting Form
+
+### Match data didn't load from TBA
+
+- Check your internet connection
+- Verify `VITE_TBA_KEY` is set and the API key is valid
+- Verify `VITE_EVENT_KEY` matches the current event
+- TBA may not have the schedule posted yet — check [thebluealliance.com](https://www.thebluealliance.com) directly
+
+### "Team is NOT in this match" warning
+
+- Double-check the match number and team number
+- The schedule may not be published yet on TBA
+- If you're sure the data is correct, continue scouting — the warning is informational
+
+### Timer started accidentally
+
+- Tap **STOP** to pause the timer
+- Tap **RESET** to clear all data and start fresh
+
+### Form won't submit
+
+- Check that all required fields are filled: scouter initials, match number, team number, and comments
+- Verify your internet connection (the form submits to Google Forms)
+- Try refreshing the page and re-entering the data
+
+### Hold buttons aren't registering
+
+- Make sure you're pressing and **holding**, not tapping
+- On mobile, avoid accidentally scrolling while holding a button
+- The timer must be running (started) for actions to record
+
+## Dashboard
+
+### Data not loading / stuck on loading screen
+
+- Check your internet connection
+- Verify `VITE_SCOUTING_CSV_URL` is a published Google Sheets link
+- Try **Quick Links > Debug — Quals** to test with sample data
+- Open browser console (F12) for specific error messages
+
+### Stale data showing
+
+- The dashboard caches data in your browser for up to 1 hour
+- **Hard refresh** (Ctrl+Shift+R on Windows, Cmd+Shift+R on Mac) to clear browser cache
+- Check that new form responses are actually appearing in the Google Sheet
+
+### Right-click context menu not appearing
+
+- **Desktop**: Right-click on a match cell in the Event Progress or Playoff Progress map
+- **Mobile**: Long-press (hold for about 1 second) on a match cell
+- Only works on **unplayed** matches — played matches show actual results
+
+### Bracket predictions look wrong
+
+- Check if actual alliance selections have been announced on TBA
+- Clear any manual overrides: right-click > "Clear Override" or use the "Clear Overrides" button
+- Predictions are based on EPA data — they may differ from your expectations
+
+### RP card tooltips not showing
+
+- Hover over the card with your mouse (desktop only)
+- The first three Win cards (duplicates) don't show tooltips — only the first Win card does
+- Tooltips require team EPA data to be loaded from Statbotics
+
+### Search/filter not working
+
+- Make sure you're typing a team number, not a team name
+- Clear the search bar to reset the filter
+
+## Scout Assignments
+
+### "No scouts loaded"
+
+- Verify `VITE_SCOUTS_CSV_URL` is set in your environment variables
+- Check that the Google Sheet is published as CSV (File > Share > Publish to web)
+- Verify the CSV has the expected column headers: `Scout Name`, `Start avail day 1`, etc.
+
+### Assignments not updating
+
+- Assignments are cached for 1 hour in localStorage
+- Click **Refresh** on the assignments page to regenerate
+- Manual clear: browser Developer Tools > Application > Local Storage > delete `scouting_assignments_cache`
+
+### Scout shows 0 assignments
+
+- Check that the scout's availability window covers the match times
+- The assignment algorithm checks match times against each scout's day 1 and day 2 availability
+
+## Debug Mode
+
+### Debug mode won't activate
+
+- Open Quick Links menu and click "Debug — Quals" or "Debug — Playoffs"
+- If the yellow banner doesn't appear, try refreshing the page
+
+### Can't exit debug mode
+
+- Click "Return to Live Dashboard" on the yellow warning banner
+- Or open Quick Links and click "Run Live Dashboard"
+- If neither works, clear localStorage and refresh the page
+
+### Debug data looks incomplete
+
+- "Debug — Quals" intentionally excludes playoff data (alliance selections and playoff matches)
+- Use "Debug — Playoffs" if you need the full dataset including playoff bracket data
+
+## Development
+
+### Build fails
+
+- Run `npm install` to ensure dependencies are current
+- Check Node.js version: `node --version` (requires Node 18+)
+- Run `npx svelte-kit sync` if type errors appear
+- Check for syntax errors in recently modified `.svelte` files
+
+### Environment variables not working
+
+- Variables must be prefixed with `VITE_` to be accessible in client code
+- **Restart the dev server** after changing `.env` — Vite doesn't hot-reload env changes
+- Check for typos in variable names
+
+### GitHub Actions deployment fails
+
+- Verify all required secrets are set in repository settings (Settings > Secrets and variables > Actions)
+- Check the workflow logs on the Actions tab for specific errors
+- The workflow requires: `TBA_API_KEY`, `EVENT_KEY`, `SCOUTING_CSV_URL`
+
+### Local dev server port conflict
+
+- If port 5173 is in use, Vite automatically tries 5174, 5175, etc.
+- Check the terminal output for the actual URL
+- Kill orphaned Node processes if ports are stuck: `npx kill-port 5173`

--- a/src/routes/scouting-dashboard/+page.svelte
+++ b/src/routes/scouting-dashboard/+page.svelte
@@ -2744,6 +2744,9 @@
               <a href="https://www.statbotics.io/event/{EVENT_KEY}" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-sm text-zinc-100 hover:bg-zinc-800 hover:text-white transition">
                 Statbotics
               </a>
+              <a href="/docs/index.html" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-sm text-zinc-100 hover:bg-zinc-800 hover:text-white transition">
+                Help Docs
+              </a>
               <div class="border-t border-zinc-700 my-1"></div>
               <button on:click={() => enterDebugMode('quals')} class="w-full text-left block px-4 py-2 text-sm font-bold transition {debugMode === 'quals' ? 'text-yellow-300 bg-yellow-500/20' : 'text-yellow-500 hover:bg-yellow-500/10 hover:text-yellow-300'}">
                 🧪 Debug — Quals

--- a/static/docs/README.md
+++ b/static/docs/README.md
@@ -1,0 +1,29 @@
+# 1757 Scouting System Documentation
+
+Documentation for FRC Team 1757's match scouting, data analysis, and strategy planning system.
+
+> [!TIP]
+> **First time?** Scouts should start with the [Competition Quick Start](competition-quickstart.md). Developers should start with [Setup & Deployment](setup-and-deployment.md).
+
+## For Scouts and Strategy
+
+| Guide | Description |
+|-------|-------------|
+| [Competition Quick Start](competition-quickstart.md) | One-page cheat sheet for event day — print this out |
+| [Scouting Form Guide](scouting-form.md) | How to fill out the scouting form during a match |
+| [Dashboard Guide](scouting-dashboard.md) | How to use every dashboard mode for analysis and strategy |
+| [Scout Assignments](scout-assignments.md) | How scout-to-match assignments work |
+
+## For Developers
+
+| Reference | Description |
+|-----------|-------------|
+| [Setup & Deployment](setup-and-deployment.md) | Environment variables, local dev, building, and deploying |
+| [Architecture](architecture.md) | Codebase structure, component map, and data flow |
+| [Data Format Reference](data-format-reference.md) | CSV schemas, timeline encoding, and API contracts |
+
+## For Everyone
+
+| Guide | Description |
+|-------|-------------|
+| [Troubleshooting](troubleshooting.md) | Common problems at competitions and how to fix them |

--- a/static/docs/architecture.md
+++ b/static/docs/architecture.md
@@ -1,0 +1,137 @@
+# Architecture
+
+> SvelteKit static site with client-side data fetching from TBA, Statbotics, and Google Sheets. All processing happens in the browser — there is no backend server.
+
+[Back to docs index](README.md)
+
+## Tech Stack
+
+| Technology | Purpose |
+|------------|---------|
+| SvelteKit 2 | Application framework |
+| Svelte 4 | Component syntax (`export let`, `on:click`, `{#each}`) |
+| Tailwind CSS | Styling (dark theme, zinc-900 backgrounds) |
+| Chart.js + svelte-chartjs | Performance trend graphs |
+| @sveltejs/adapter-static | Builds to static HTML/JS for GitHub Pages |
+| GitHub Actions | Auto-deployment from `next` branch |
+
+## Project Structure
+
+```
+src/
+  routes/
+    scouting/+page.svelte                    # Scouting form (~560 lines)
+    scouting-dashboard/+page.svelte           # Main dashboard (~4300 lines)
+    scouting-assignments/+page.svelte         # Scout assignments (~940 lines)
+  components/
+    scoutingDashboard/
+      CoverageMap.svelte                      # Match coverage grid
+      CoverageMapButton.svelte                # Individual coverage cell with long-press
+      EventProgressMap.svelte                 # Quals prediction map with overrides
+      PlayoffProgressMap.svelte               # Playoff bracket visualization
+      RPCards.svelte                          # Ranking point prediction cards
+      SimulatorHeader.svelte                  # Simulator alliance header display
+      SimulatorTeamCard.svelte                # Team card with stats and autocomplete
+      ContextMenu.svelte                      # Right-click menu for simulator loading
+      OverrideContextMenu.svelte              # Right-click menu for match overrides
+      utils.js                                # Shared utilities
+static/
+  test-data/                                  # Fallback data for debug mode
+.github/
+  workflows/AutoDeploy.yml                    # GitHub Pages deployment
+```
+
+## Data Flow
+
+```
+Google Forms  →  Google Sheets  →  Published CSV  →  Dashboard (client-side fetch)
+                                                         ↕
+TBA API  ────────────────────────────────────────→  Dashboard (schedule, rankings, alliances)
+                                                         ↕
+Statbotics API  ─────────────────────────────────→  Dashboard (EPA, match predictions)
+                                                         ↕
+FRC Colors API  ─────────────────────────────────→  Dashboard (team color theming)
+```
+
+1. Scouts fill out the scouting form at `/scouting` during matches
+2. Form data submits to Google Forms, which populates a Google Sheet
+3. The dashboard fetches the Sheet as CSV via the published URL
+4. The dashboard also fetches TBA and Statbotics data for EPA, schedule, and rankings
+5. All data processing (filtering, sorting, aggregation, predictions) happens client-side
+
+## External APIs
+
+| API | Base URL | Auth | Used For |
+|-----|----------|------|----------|
+| The Blue Alliance | `thebluealliance.com/api/v3` | `X-TBA-Auth-Key` header | Schedule, rankings, OPRs, alliances, team details |
+| Statbotics | `api.statbotics.io/v3` | None (public) | EPA ratings, match predictions, year statistics |
+| FRC Colors | `api.frc-colors.com/v1` | None (public) | Team primary/secondary hex colors |
+| Google Sheets | Published CSV URL | None (public link) | Scouting data, pit data, scout roster |
+| Google Forms | Form submission URL | None | Scouting form target |
+
+## Key Patterns
+
+### Hold-to-Time Buttons
+
+The scouting form uses `mousedown`/`touchstart` to begin timing an action and `mouseup`/`touchend` to stop. Each press creates a `start` timeline entry and each release creates a `stop` entry. Duration = stop time - start time.
+
+### Timeline Serialization
+
+Actions are encoded as `code:type@time` entries joined by semicolons. The `parseActions()` function in `utils.js` deserializes this into structured objects. The `getGanttData()` function converts these into Gantt chart visualization data.
+
+### Debug Mode
+
+A `debugMode` state variable (`null`, `'quals'`, or `'playoffs'`) controls whether fetch functions hit live APIs or load from `/static/test-data/`. When active, CSV fetches redirect to test CSV files and TBA fetches go straight to local JSON fallbacks.
+
+### Context Menus
+
+Two interaction patterns for the same action:
+- **Desktop**: `contextmenu` event (right-click) opens a positioned menu
+- **Mobile**: `pointerdown` with a 600ms `setTimeout` triggers long-press behavior
+- Both pointer handlers filter `e.button !== 0` to prevent right-click from triggering left-click actions
+
+### Reactive Derivations
+
+The dashboard makes heavy use of Svelte's `$:` reactive statements. The playoff bracket simulation, for example, chains through multiple reactive blocks:
+
+```
+teamStatsMap → allianceSimulation → effectiveAlliances → bracketSimulation
+```
+
+Map-based reactivity uses an IIFE pattern to ensure Svelte tracks changes:
+```js
+$: bracketSimulation = ((overrides) => { /* ... */ })(playoffOverrides);
+```
+
+### LocalStorage Caching
+
+- **Dashboard**: Caches scouting data, team stats, colors, and details for 1 hour
+- **Assignments**: Caches generated assignments for 1 hour
+- Debug mode clears the cache on activation/deactivation
+
+## Component Responsibilities
+
+| Component | Props (Key) | Responsibility |
+|-----------|-------------|----------------|
+| `CoverageMap` | schedule, searchTerm, getScouterCount | Renders grid of match coverage cells |
+| `CoverageMapButton` | match, scouterCount, breakdown | Single coverage cell with hover tooltip |
+| `EventProgressMap` | schedule, matchPredictions, hoveredMatch | Quals progress grid with click/override handlers |
+| `PlayoffProgressMap` | bracketMatches, alliances, playoffOverrides | Playoff match grid with override support |
+| `RPCards` | alliance, predictions (with reasons) | 6 RP indicator cards with hover tooltips |
+| `SimulatorHeader` | alliance, teams, epa, opr | Alliance summary bar in simulator |
+| `SimulatorTeamCard` | team, stats, suggestions | Team input card with autocomplete |
+| `ContextMenu` | contextMenu, match | Right-click menu: "Load in Simulator" |
+| `OverrideContextMenu` | contextMenu, matchLabel, redLabel, blueLabel | Right-click menu: override/clear match prediction |
+
+## Utility Functions (`utils.js`)
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `getVal` | `(obj, key) → string` | Safe property accessor, returns `''` if missing |
+| `parseActions` | `(actionStr) → [{code, type, time}]` | Parse timeline string into sorted action array |
+| `getGanttData` | `(actionStr) → [{code, events}]` | Convert timeline into Gantt chart data structure |
+| `getActionColor` | `(code) → string` | Map action code to Tailwind CSS color class |
+
+---
+
+See [Data Format Reference](data-format-reference.md) for detailed schemas or [Setup & Deployment](setup-and-deployment.md) for configuration.

--- a/static/docs/competition-quickstart.md
+++ b/static/docs/competition-quickstart.md
@@ -1,0 +1,53 @@
+# Competition Quick Start
+
+> One-page reference for event day. Print this out and bring it to the competition.
+
+[Back to docs index](README.md)
+
+## URLs
+
+| Page | URL | Purpose |
+|------|-----|---------|
+| Scouting Form | `/scouting` | Fill out during each match |
+| Dashboard | `/scouting-dashboard` | Analyze data, run simulations |
+| Assignments | `/scouting-assignments` | Check your match assignments |
+
+## Scout Workflow (Per Match)
+
+1. Check your assignment on the Assignments page
+2. Open the Scouting Form on your device
+3. Enter your **initials**, **match number**, and **team number**
+4. Verify the team appears in the TBA auto-fetch (green highlight = correct)
+5. Select **starting position** on the field diagram
+6. Tap **START** when the match begins (or it auto-starts on first button press)
+7. **Hold buttons** while your robot performs each action — release when the action ends
+8. Fill out **endgame** fields (climb level, climb position, any issues)
+9. Rate **scoring effectiveness**, **feeding skill**, and **defense skill** (0-5 each)
+10. Write a **comment** (required — we read every one)
+11. Tap **SUBMIT**
+
+> [!IMPORTANT]
+> Hold-to-time buttons track *duration*. Press and hold for as long as the robot performs the action. Don't tap — hold.
+
+## Dashboard Modes
+
+| Mode | Color | What It Shows | When to Use |
+|------|-------|---------------|-------------|
+| Leaderboard | Green | EPA/OPR rankings for all teams | Default view between matches |
+| Simulator | Blue | 3v3 alliance comparison | Before a specific match |
+| Selection | Orange | EPA-ranked pick list | During alliance selection |
+| Defense | Red | Defensive effectiveness ratings | Evaluating defenders |
+| Overview | Purple | Single-team deep dive | Pre-match strategy prep |
+| Pit | White | Pit scouting data and robot photos | Walk-around / pit visits |
+| Scout Lead | Yellow | Missing scouting coverage | Between matches, filling gaps |
+
+## Quick Tips
+
+- **Right-click** (desktop) or **long-press** (mobile) on match cards to override predictions
+- **Click any match** in the progress maps to load it into the simulator
+- Use **Quick Links** menu for fast access to TBA, Statbotics, and forms
+- **Debug mode** (Quick Links menu) loads test data for practice — don't use at competition
+
+## If Something Breaks
+
+See [Troubleshooting](troubleshooting.md) for common problems and fixes.

--- a/static/docs/data-format-reference.md
+++ b/static/docs/data-format-reference.md
@@ -1,0 +1,227 @@
+# Data Format Reference
+
+> Schemas for CSV data, timeline encoding, and API response shapes used by the scouting system.
+
+[Back to docs index](README.md)
+
+## Scouting CSV Columns
+
+These columns appear in the Google Sheet that receives scouting form responses. The dashboard fetches this sheet as CSV.
+
+| Column | Form Field ID | Type | Example |
+|--------|--------------|------|---------|
+| Scouter Initials | `entry.55361842` | text | `ABC` |
+| Match # | `entry.528540297` | number | `12` |
+| Team # | `entry.1130076361` | number | `1757` |
+| Starting position? | `entry.236449401` | enum | `OT` |
+| No Show | `entry.65205079` | checkbox | `no show` |
+| Timeline | `entry.2000596765` | serialized | see [Timeline Format](#timeline-format) |
+| Auto Climb Result | `entry.287801541` | enum | `No`, `Out`, `Mid`, `Dep`, `F` |
+| Alliance won auto? | `entry.901735072` | checkbox | `true` |
+| Defended by opponent? | `entry.942649623` | checkbox | `true` |
+| Climb Level | `entry.477247024` | enum | `No`, `L1`, `L2`, `L3`, `F` |
+| Climb Position | `entry.1268059521` | enum | `No`, `Out`, `Mid`, `Dep` |
+| Mech Issue | `entry.676569017` | checkbox | `true` |
+| Died | `entry.1940984634` | checkbox | `true` |
+| Tipped | `entry.1961795439` | checkbox | `true` |
+| Scoring effectiveness? | `entry.975098497` | 0-5 | `4` |
+| Scored How? | `entry.1864643366` | enum | `While driving` |
+| Scoring Locations | `entry.728375142` | multi | `1`, `2`, `3` |
+| Feeding Skill | `entry.2132357592` | 0-5 | `3` |
+| Passed How? | `entry.788387708` | enum | `While stationary` |
+| Defense Skill | `entry.1384370540` | 0-5 | `2` |
+| Card | `entry.1816355809` | enum | `No Card`, `Yellow`, `Red` |
+| Comments | `entry.568874806` | text | free text |
+| GambleScout prediction | `entry.908293542` | enum | `b` or `r` |
+
+> [!NOTE]
+> The CSV uses a 2-row header (row 1 = Google Form internal labels, row 2 = column headers). The dashboard's CSV parser skips the first 2 rows using `parseCSV(text, 2)`.
+
+## Pit Scouting CSV Columns
+
+| Column | Type | Example |
+|--------|------|---------|
+| Team number | number | `1757` |
+| Drive Train Type | text | `Swerve` |
+| Frame dimensions | text | `28x28` |
+| Weight | text | `120 lbs` |
+| Under trench? | text | `Yes` |
+| Over bump? | text | `Yes` |
+| Drive Coach | text | `Jane Smith` |
+| Team Friendliness | text | `Very friendly` |
+| Best Auto | text | `3 piece auto` |
+| Bot pic | URL | Google Drive image URL |
+
+The pit CSV uses a 1-row header: `parseCSV(text, 1)`.
+
+## Timeline Format
+
+Actions during a match are serialized as a semicolon-delimited string of entries.
+
+### Entry Format
+
+```
+{code}:{type}@{time}
+```
+
+| Component | Values | Description |
+|-----------|--------|-------------|
+| `code` | Action code string | Which action was performed |
+| `type` | `start`, `stop`, `point` | Start/stop of a held action, or an instant event |
+| `time` | Integer (seconds) | Seconds elapsed since the match timer started |
+
+### Example
+
+```
+auto_score:start@3;auto_score:stop@8;tele_fuel:point@45;tele_def:start@60;tele_def:stop@90
+```
+
+This means:
+- Scoring from 3s to 8s during auto (5-second action)
+- Fuel scored at 45s during teleop (instant)
+- Defense played from 60s to 90s during teleop (30-second action)
+
+### Action Codes
+
+#### Autonomous (Hold-to-Time)
+
+| Code | Action |
+|------|--------|
+| `auto_score` | Scoring game pieces |
+| `auto_pass` | Passing to alliance partners |
+| `auto_outpost` | Collecting from outpost |
+| `auto_depot` | Collecting from depot |
+| `auto_ground` | Collecting from ground |
+| `auto_climb` | Climbing |
+| `auto_trench` | Traversing the trench |
+| `auto_faff` | Wasting time (stuck, confused) |
+
+#### Teleop (Hold-to-Time)
+
+| Code | Action |
+|------|--------|
+| `tele_score` | Scoring game pieces |
+| `tele_coll` | Collecting game pieces |
+| `tele_pass` | Passing to alliance partners |
+| `tele_faff` | Wasting time |
+| `tele_def` | Playing defense |
+| `tele_climb` | Climbing |
+| `tele_alliance` | In alliance zone |
+| `tele_neutral` | In neutral zone |
+| `tele_opponent` | In opponent zone |
+
+#### Instant Actions (Tap Counters)
+
+| Code | Action |
+|------|--------|
+| `auto_fuel` | Fuel scored during auto |
+| `tele_fuel` | Fuel scored during teleop |
+| `tele_fed` | Fuel fed to alliance partner |
+
+### Action Color Mapping
+
+Used by `getActionColor()` in `utils.js` for Gantt chart visualization:
+
+| Code Contains | Color |
+|---------------|-------|
+| `score` | Green (`bg-green-500`) |
+| `coll`, `outpost`, `depot`, `ground` | Blue (`bg-blue-500`) |
+| `pass` | Orange (`bg-orange-500`) |
+| `climb` | Purple (`bg-purple-500`) |
+| `die` | Red (`bg-red-500`) |
+| `card` | Yellow (`bg-yellow-500`) |
+| `tip` | Pink (`bg-pink-500`) |
+| Other | Gray (`bg-zinc-500`) |
+
+## Starting Position Codes
+
+| Code | Field Position |
+|------|---------------|
+| `OT` | Outpost Trench |
+| `OBFT` | Outpost Bump Favoring Trench |
+| `OBFH` | Outpost Bump Favoring Hub |
+| `H` | Hub |
+| `DBFH` | Depot Bump Favoring Hub |
+| `DBFT` | Depot Bump Favoring Trench |
+| `DT` | Depot Trench |
+| `NS` | No position / no show |
+
+## Climb Enums
+
+### Auto Climb Result
+
+| Value | Meaning |
+|-------|---------|
+| `No` | No climb attempted |
+| `Out` | Output side |
+| `Mid` | Middle |
+| `Dep` | Depot side |
+| `F` | Failed climb |
+
+### Endgame Climb Level
+
+| Value | Meaning |
+|-------|---------|
+| `No` | No climb |
+| `L1` | Level 1 |
+| `L2` | Level 2 |
+| `L3` | Level 3 |
+| `F` | Failed climb |
+
+### Endgame Climb Position
+
+Same as Auto Climb Result: `No`, `Out`, `Mid`, `Dep`.
+
+## Scoring Location Codes
+
+| Value | Location |
+|-------|----------|
+| `1` | Outpost Trench |
+| `2` | Outpost |
+| `3` | Hub |
+| `4` | Ladder |
+| `5` | Depot |
+| `6` | Depot Trench |
+
+## Win Probability Formula
+
+The dashboard calculates win probability from EPA difference:
+
+```
+winProb = 1 / (1 + 10^((-5/8 * scoreDiff) / score_sd))
+```
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `scoreDiff` | Red EPA sum - Blue EPA sum | EPA advantage of red alliance |
+| `score_sd` | Statbotics year stats | Standard deviation of scores (default: ~20) |
+
+Result: probability from 0 to 1 that the red alliance wins.
+
+## RP Prediction Thresholds
+
+| Metric | Lit (Likely) | Contention (Possible) | Muted (Unlikely) |
+|--------|-------------|----------------------|-------------------|
+| RP sum (rp1/rp2/rp3) | > 1.0 | > 0.8 | <= 0.8 |
+| Win probability | > 62.5% | 37.5% - 62.5% | < 37.5% |
+
+RP sum = sum of individual team EPA RP values for the 3 alliance teams.
+
+## Test Data Files
+
+Located in `/static/test-data/`. Used by [debug mode](scouting-dashboard.md#debug-mode) and as fallback when API calls fail.
+
+| File | Format | Contents |
+|------|--------|----------|
+| `scouting.csv` | CSV | 180 mock scouting entries |
+| `pit.csv` | CSV | 32 teams of mock pit data |
+| `schedule.json` | JSON (TBA format) | 60 qualification matches |
+| `playoff-schedule.json` | JSON (TBA format) | 14 playoff matches (8 played, 6 unplayed) |
+| `rankings.json` | JSON (TBA format) | 32 team rankings |
+| `alliances.json` | JSON (TBA format) | 8 alliance selections |
+| `oprs.json` | JSON (TBA format) | OPR values for all teams |
+| `teams.json` | JSON | Array of team keys (`["frc61", "frc78", ...]`) |
+
+---
+
+See [Architecture](architecture.md) for how these formats are used in the codebase.

--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1757 Scouting System Docs</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown-dark.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    body {
+      background: #0d1117;
+      color: #e6edf3;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      margin: 0;
+      display: flex;
+      min-height: 100vh;
+    }
+    nav {
+      width: 260px;
+      min-width: 260px;
+      background: #161b22;
+      border-right: 1px solid #30363d;
+      padding: 20px;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      box-sizing: border-box;
+    }
+    nav h2 {
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 1.5px;
+      color: #8b949e;
+      margin: 20px 0 8px;
+    }
+    nav h2:first-child { margin-top: 0; }
+    nav a {
+      display: block;
+      padding: 6px 10px;
+      margin: 2px 0;
+      color: #58a6ff;
+      text-decoration: none;
+      font-size: 14px;
+      border-radius: 6px;
+      transition: background 0.15s;
+    }
+    nav a:hover { background: #1f2937; }
+    nav a.active { background: #1f6feb33; color: #79c0ff; font-weight: 600; }
+    main {
+      flex: 1;
+      max-width: 900px;
+      padding: 40px 50px;
+    }
+    .markdown-body {
+      background: transparent;
+    }
+    .markdown-body table { display: table; width: 100%; }
+    .markdown-body blockquote {
+      border-left-color: #3b82f6;
+      color: #8b949e;
+    }
+    /* GitHub-style callouts */
+    .markdown-body blockquote p:first-child {
+      font-weight: normal;
+    }
+    @media (max-width: 768px) {
+      body { flex-direction: column; }
+      nav {
+        width: 100%;
+        min-width: 100%;
+        height: auto;
+        position: static;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        padding: 12px;
+      }
+      nav h2 { width: 100%; margin: 8px 0 4px; }
+      nav a { display: inline-block; }
+      main { padding: 20px; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <h2>Scouts & Strategy</h2>
+    <a href="#" data-page="competition-quickstart">Competition Quick Start</a>
+    <a href="#" data-page="scouting-form">Scouting Form Guide</a>
+    <a href="#" data-page="scouting-dashboard">Dashboard Guide</a>
+    <a href="#" data-page="scout-assignments">Scout Assignments</a>
+    <h2>Developers</h2>
+    <a href="#" data-page="setup-and-deployment">Setup & Deployment</a>
+    <a href="#" data-page="architecture">Architecture</a>
+    <a href="#" data-page="data-format-reference">Data Format Reference</a>
+    <h2>Everyone</h2>
+    <a href="#" data-page="troubleshooting">Troubleshooting</a>
+  </nav>
+  <main>
+    <article id="content" class="markdown-body"></article>
+  </main>
+  <script>
+    const contentEl = document.getElementById('content');
+    const links = document.querySelectorAll('nav a[data-page]');
+
+    async function loadPage(page) {
+      try {
+        const res = await fetch(page + '.md');
+        if (!res.ok) throw new Error('Not found');
+        let md = await res.text();
+        // Convert GitHub callouts to styled HTML
+        md = md.replace(/> \[!(TIP|IMPORTANT|WARNING|NOTE)\]\n>/g, (_, type) => {
+          const colors = { TIP: '#3fb950', IMPORTANT: '#a371f7', WARNING: '#d29922', NOTE: '#58a6ff' };
+          const icons = { TIP: '💡', IMPORTANT: '❗', WARNING: '⚠️', NOTE: 'ℹ️' };
+          return `> ${icons[type]} **${type}**\n>`;
+        });
+        contentEl.innerHTML = marked.parse(md);
+        // Update active link
+        links.forEach(l => l.classList.toggle('active', l.dataset.page === page));
+        // Update URL hash
+        window.location.hash = page;
+        // Scroll to top
+        window.scrollTo(0, 0);
+      } catch (e) {
+        contentEl.innerHTML = '<h1>Page not found</h1><p>Could not load ' + page + '.md</p>';
+      }
+    }
+
+    // Handle nav clicks
+    links.forEach(link => {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        loadPage(link.dataset.page);
+      });
+    });
+
+    // Handle in-page markdown links
+    contentEl.addEventListener('click', (e) => {
+      const a = e.target.closest('a');
+      if (!a) return;
+      const href = a.getAttribute('href');
+      if (href && href.endsWith('.md')) {
+        e.preventDefault();
+        const page = href.replace('.md', '').replace('./', '');
+        if (page === 'README') {
+          loadPage('competition-quickstart');
+        } else {
+          loadPage(page);
+        }
+      }
+    });
+
+    // Load initial page from hash or default
+    const initialPage = window.location.hash.slice(1) || 'competition-quickstart';
+    loadPage(initialPage);
+  </script>
+</body>
+</html>

--- a/static/docs/scout-assignments.md
+++ b/static/docs/scout-assignments.md
@@ -1,0 +1,82 @@
+# Scout Assignments
+
+> Automatically assign scouts to teams based on availability windows and workload balance.
+
+[Back to docs index](README.md)
+
+## Setup Requirements
+
+Before assignments can be generated, you need:
+
+1. **Scouts CSV** — A Google Sheet with scout names and availability, published as CSV
+2. **TBA API key** — Set as `VITE_TBA_KEY` environment variable
+3. **Event key** — Set as `VITE_EVENT_KEY` (defaults to `2026rikin`)
+4. **Scouts CSV URL** — Set as `VITE_SCOUTS_CSV_URL`
+
+### Scouts CSV Format
+
+The Google Sheet must have these columns:
+
+| Column | Example | Description |
+|--------|---------|-------------|
+| Scout Name | Jane Smith | Full name of the scout |
+| Start avail day 1 | 4/4/2026 8:00:00 | When the scout is available on day 1 |
+| End avail day 1 | 4/4/2026 17:00:00 | When the scout leaves on day 1 |
+| Start avail day 2 | 4/5/2026 8:00:00 | When the scout is available on day 2 |
+| End avail day 2 | 4/5/2026 17:00:00 | When the scout leaves on day 2 |
+
+Publish the sheet: **File > Share > Publish to web > CSV format**.
+
+## How Assignment Works
+
+The algorithm assigns scouts to matches in batches of 5, balancing workload:
+
+1. **Batching** — Matches are grouped into batches of 5 to give scouts breaks between assignments
+2. **Availability check** — Only scouts available during the match time window are considered
+3. **Load balancing** — Scouts with the largest gap since their last assignment are picked first
+4. **Tiebreaking** — If gaps are equal, the scout with fewer total assignments is chosen
+5. **No duplicates** — A scout is never assigned twice in the same batch
+
+Each match needs 6 scouts (one per robot: 3 red alliance + 3 blue alliance).
+
+## Using the Assignments Page
+
+Navigate to `/scouting-assignments`.
+
+### Scouts Panel (Left)
+
+- Lists all scouts with their availability windows
+- Shows total assignment count per scout
+- Click a scout's name to view their personal timeline
+
+### Assignments Panel (Right)
+
+- **Scout Timeline** — Shows selected scout's matches with break durations between them
+- **All Assignments** — Grid showing every match with assigned scouts, separated by alliance
+- Match times shown in color: green (actual), blue (predicted), gray (scheduled)
+
+### Match Time Display
+
+| Color | Meaning |
+|-------|---------|
+| Green | Actual match time from TBA |
+| Blue | Predicted time based on schedule |
+| Gray | Scheduled time (no prediction available) |
+
+Day separators and end-of-day markers help scouts plan their time.
+
+## Caching
+
+Assignments are cached in your browser's localStorage for **1 hour**. This avoids regenerating assignments on every page load.
+
+- The cache age is displayed on the page
+- Click **Refresh** to force regeneration
+- Clear browser cache manually: Developer Tools > Application > Local Storage > delete `scouting_assignments_cache`
+
+## Coordinating with the Dashboard
+
+Use **Scout Lead mode** on the [Dashboard](scouting-dashboard.md) to check for coverage gaps. If a match is missing scouting data, check whether the assigned scout was unavailable or reassign manually.
+
+---
+
+See [Troubleshooting](troubleshooting.md) if assignments aren't loading.

--- a/static/docs/scouting-dashboard.md
+++ b/static/docs/scouting-dashboard.md
@@ -1,0 +1,204 @@
+# Scouting Dashboard Guide
+
+> Analyze scouting data, predict match outcomes, and prepare for alliance selection. The dashboard pulls data from multiple sources and provides seven analysis modes.
+
+[Back to docs index](README.md)
+
+## Getting Started
+
+Navigate to `/scouting-dashboard`. The dashboard automatically loads data from:
+
+- **Google Sheets** — Scouting and pit data submitted through the forms
+- **The Blue Alliance** — Match schedule, rankings, OPRs, and alliance selections
+- **Statbotics** — EPA (Expected Points Added) ratings and match predictions
+- **FRC Colors** — Team color theming
+
+Loading indicators show progress for each data source. If a source fails, the dashboard continues with available data.
+
+## Dashboard Modes
+
+Toggle between modes using the buttons at the top. Only one mode is active at a time.
+
+### Leaderboard (Default)
+
+The default view when you open the dashboard.
+
+- All teams ranked by EPA from Statbotics
+- Sortable columns for EPA, OPR, and scouting averages
+- Click any team row to expand match-by-match scouting detail
+- Use the search bar to filter by team number
+
+### Simulator
+
+Compare two alliances in a 3v3 simulation.
+
+- Enter team numbers in the three red and three blue slots
+- View aggregated EPA, OPR, and win probability
+- **RP Prediction Cards** show Ranking Point likelihood for each alliance (Energized, Supercharged, Traversal, Win)
+- Hover over any RP card to see the per-team EPA breakdown and threshold reasoning
+- Performance charts show trends for each team
+
+**Loading matches into the simulator:**
+- Click any match in the Event Progress or Playoff Progress maps
+- Right-click a match in the Coverage Map and select "Load in Simulator"
+- Long-press a match on mobile to load it
+
+### Alliance Selection Mode
+
+EPA-ranked pick list for alliance selection.
+
+- Teams ranked by EPA with optimal alliance pairings
+- Simulates the 8-alliance snake draft order
+- Click teams to cross them off as they're picked by other alliances
+- Updates in real time as the draft progresses
+
+### Defense Mode
+
+Defensive effectiveness analysis.
+
+- Teams ranked by defense skill ratings from scouting data
+- Filters for defense-specific metrics
+- Helps identify strong defenders for alliance strategy
+
+### Overview Mode
+
+Single-team deep dive.
+
+- Select a team to view all their match data in one place
+- **Performance trend charts** — Line graphs across matches for scoring, feeding, and defense
+- **Action timelines** — Gantt-style visualization of what the robot did during each match
+- **Starting position distribution** — Where the team typically starts
+- **Pit scouting data** — Robot specs and photos (if available)
+- **Consistency metrics** — Early-game vs. late-game effectiveness
+
+### Pit Mode
+
+Pit scouting data display.
+
+- Shows pit scouting responses for each team
+- Drive train type, frame dimensions, weight, and capabilities
+- Image viewer for robot photos with pinch-to-zoom on mobile
+
+### Scout Lead Mode
+
+Assignment management and coverage tracking.
+
+- Shows matches with missing scouting coverage
+- Lists which teams still need to be scouted per match
+- Use between matches to identify and fill coverage gaps
+- Cross-reference with the Coverage Map for a visual overview
+
+## Visual Components
+
+### Coverage Map
+
+A grid showing which team/match combinations have been scouted.
+
+- **Green** = Fully scouted (all 6 robots in the match have data)
+- **Partial** = Some robots scouted, some missing
+- **Empty** = No scouting data for this match
+- Right-click any match to load it into the simulator
+
+### Event Progress Map (Quals)
+
+A color-coded grid of all qualification matches showing predictions and results.
+
+| Color | Meaning |
+|-------|---------|
+| Muted red | Red alliance won (actual result) |
+| Muted blue | Blue alliance won (actual result) |
+| Bright red | Red predicted to win (unplayed) |
+| Bright blue | Blue predicted to win (unplayed) |
+| Gray | Toss-up (close prediction) |
+| Yellow ring | Manual override applied |
+
+- Hover over any match for a tooltip showing teams and prediction details
+- Click to load the match into the simulator
+
+### Playoff Progress Map
+
+A compact grid of all playoff bracket matches (M1-M14).
+
+- Same color scheme as the Event Progress Map
+- Predictions flow through the double-elimination bracket
+- Override any unplayed match to see how results cascade
+
+### RP Prediction Cards
+
+Six cards per alliance in the simulator showing Ranking Point predictions:
+
+| Card | RP Type | Threshold |
+|------|---------|-----------|
+| Energized | RP1 | Sum of team EPA RP1 values |
+| Supercharged | RP2 | Sum of team EPA RP2 values |
+| Traversal | RP3 | Sum of team EPA RP3 values |
+| Win (x3) | Win bonus | EPA-based win probability |
+
+**Card states:**
+- **Lit** (bright color) — Likely (RP sum > 1.0 or win prob > 62.5%)
+- **Contention** (dim color) — Possible (RP sum > 0.8 or win prob 37.5-62.5%)
+- **Muted** (gray) — Unlikely (RP sum <= 0.8 or win prob < 37.5%)
+
+Hover over any card for the detailed breakdown.
+
+### Playoff Bracket
+
+Full double-elimination bracket display showing all 14 matches:
+
+- **Upper Bracket**: Round 1 (M1-M4), Round 2 (M5-M6), Upper Final (M7)
+- **Lower Bracket**: Lower Round 2 (M8-M9), Lower Round 3 (M10-M11), Lower Round 4 (M12), Lower Final (M13)
+- **Grand Finals**: M14 (+ optional M15 tiebreaker)
+
+Click any match to load those alliance teams into the simulator.
+
+## What-If Overrides
+
+Override any match prediction to explore "what-if" scenarios. Overrides cascade through the bracket and ranking predictions.
+
+**Desktop:** Right-click on an unplayed match card → select "Override Red", "Override Blue", or "Clear Override"
+
+**Mobile:** Long-press (hold ~1 second) on an unplayed match card to cycle through override options
+
+**Clearing overrides:**
+- Right-click → "Clear Override" clears a single match
+- "Clear Overrides" button (next to section headers) clears all overrides in that section
+
+> [!NOTE]
+> For playoff matches, the override menu shows "Override Alliance {N}" instead of red/blue, since playoff alliances don't correspond to a fixed color.
+
+## Quick Links Menu
+
+Access external tools and debug options from the Quick Links dropdown:
+
+| Link | Destination |
+|------|-------------|
+| Pit Scouting Form | Google Form for pit data (if configured) |
+| Scouting Form | `/scouting` form page |
+| Scouting Assignments | `/scouting-assignments` page |
+| TBA Event | The Blue Alliance event page |
+| Statbotics | Statbotics event page |
+| Help Docs | This documentation |
+
+### Debug Mode
+
+> [!WARNING]
+> Debug mode loads fake test data. Don't activate this during a real competition.
+
+Access via Quick Links:
+
+- **Debug — Quals**: Loads test qualification data. Playoffs run in pure prediction mode (no actual alliances).
+- **Debug — Playoffs**: Loads all test data including playoff results and alliance selections.
+- **Run Live Dashboard**: Returns to live API data (only shown when debug mode is active).
+
+A yellow warning banner appears at the top of the dashboard when debug mode is active.
+
+## Other Features
+
+- **Fullscreen mode** — Toggle with the fullscreen button in the header
+- **Team search** — Type a team number to filter all views
+- **Data caching** — Data is cached in your browser for 1 hour. Hard refresh (Ctrl+Shift+R) to force a reload.
+- **Match videos** — YouTube match videos can be embedded when available
+
+---
+
+See [Troubleshooting](troubleshooting.md) if data isn't loading or features aren't working.

--- a/static/docs/scouting-form.md
+++ b/static/docs/scouting-form.md
@@ -1,0 +1,218 @@
+# Scouting Form Guide
+
+> Collect match data by holding buttons while robots perform actions. The form captures timing data, performance ratings, and observer comments.
+
+[Back to docs index](README.md)
+
+## Before the Match
+
+### Pre-Match Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Scouter Initials | Yes | Your initials (identifies who scouted) |
+| Match Number | Yes | The qualification match number |
+| Team Number | Yes | The team you're assigned to watch |
+| Starting Position | Yes | Where the robot starts on the field |
+| No Show | No | Check if the robot doesn't appear on the field |
+
+### TBA Auto-Fetch
+
+When you enter a **match number**, the form automatically fetches alliance data from The Blue Alliance:
+
+- Displays red and blue alliance team numbers (R1, R2, R3 / B1, B2, B3)
+- Validates your team number is in the match (green = correct, red = wrong match)
+- Loads Statbotics win predictions for GambleScout
+
+### Starting Positions
+
+| Code | Position |
+|------|----------|
+| OT | Outpost Trench |
+| OBFT | Outpost Bump Favoring Trench |
+| OBFH | Outpost Bump Favoring Hub |
+| H | Hub |
+| DBFH | Depot Bump Favoring Hub |
+| DBFT | Depot Bump Favoring Trench |
+| DT | Depot Trench |
+| NS | No position / no show |
+
+### GambleScout (Optional)
+
+A fun prediction game that appears after match data loads. Predict which alliance wins — you can only gain points, never lose them. Point values are weighted by how unlikely your pick is (betting on the underdog pays more).
+
+## During the Match: Autonomous
+
+> [!IMPORTANT]
+> **Hold-to-time buttons**: Press and hold while the robot performs the action. Release when the action ends. The duration is recorded automatically.
+
+### Autonomous Action Buttons
+
+| Button | Code | What to Track |
+|--------|------|---------------|
+| SCORING | `auto_score` | Robot is actively scoring game pieces |
+| PASSING | `auto_pass` | Robot is passing game pieces to alliance partners |
+| OUTPOST COLL | `auto_outpost` | Robot is collecting from the outpost |
+| DEPOT COLL | `auto_depot` | Robot is collecting from the depot |
+| GROUND COLL | `auto_ground` | Robot is collecting from the ground |
+| CLIMBING | `auto_climb` | Robot is attempting to climb |
+| TRENCH | `auto_trench` | Robot is traversing the trench |
+| FAFFING | `auto_faff` | Robot is wasting time (stuck, confused, etc.) |
+
+### Auto Climb Result
+
+After autonomous ends, select the climb result:
+
+| Option | Meaning |
+|--------|---------|
+| No | Did not attempt climb |
+| Output Side | Climbed on output side |
+| Middle | Climbed in the middle |
+| Depot Side | Climbed on depot side |
+| Failed Climb | Attempted but failed |
+
+## During the Match: Teleop
+
+Same hold-to-time pattern with teleop-specific actions:
+
+### Teleop Action Buttons
+
+| Button | Code | What to Track |
+|--------|------|---------------|
+| SCORING | `tele_score` | Robot is actively scoring |
+| COLLECTING | `tele_coll` | Robot is collecting game pieces |
+| PASSING | `tele_pass` | Robot is passing to partners |
+| FAFFING | `tele_faff` | Robot is wasting time |
+| DEFENSE | `tele_def` | Robot is playing defense |
+| CLIMBING | `tele_climb` | Robot is climbing |
+| ALLIANCE ZONE | `tele_alliance` | Robot is in the alliance zone |
+| NEUTRAL ZONE | `tele_neutral` | Robot is in the neutral zone |
+| OPPONENT ZONE | `tele_opponent` | Robot is in the opponent zone |
+
+### Teleop Counters (Tap to Increment)
+
+| Button | Code | What to Track |
+|--------|------|---------------|
+| Fuel Scored | `tele_fuel` | Each fuel piece scored (tap once per piece) |
+| Fuel Fed | `tele_fed` | Each fuel piece fed to partner |
+
+### Teleop Checkboxes
+
+- **Alliance won auto?** — Check if your alliance won the autonomous period
+- **Defended by opponent?** — Check if an opponent robot played defense on your team
+
+## After the Match: Endgame
+
+### Climb Level
+
+| Option | Meaning |
+|--------|---------|
+| No Climb | Did not climb |
+| L1 | Level 1 climb |
+| L2 | Level 2 climb |
+| L3 | Level 3 climb |
+| Failed Climb | Attempted but failed |
+
+### Climb Position
+
+| Option | Meaning |
+|--------|---------|
+| No Climb | Did not climb |
+| Output Side | Climbed on output side |
+| Middle | Climbed in the middle |
+| Depot Side | Climbed on depot side |
+
+### Issue Checkboxes
+
+- **Mech Issue** — Robot had a mechanical problem during the match
+- **Died** — Robot stopped functioning entirely
+- **Tipped** — Robot tipped over during the match
+
+## After the Match: Ratings
+
+### Scoring Effectiveness (0-5)
+
+Rate how effectively the robot scored game pieces. Use the slider.
+
+- **0** = Did not score at all
+- **5** = Extremely effective scorer
+
+### Scored How?
+
+| Option | Meaning |
+|--------|---------|
+| While driving | Scored while in motion |
+| While stationary | Scored from a fixed position |
+| Both | Used both methods |
+| No scoring | Did not score |
+
+### Scoring Locations
+
+Check all field zones where the robot scored (checkboxes, multiple allowed):
+
+1. Outpost Trench
+2. Outpost
+3. Hub
+4. Ladder
+5. Depot
+6. Depot Trench
+
+### Feeding Skill (0-5)
+
+Rate how effectively the robot passed/fed game pieces to alliance partners.
+
+### Passed How?
+
+Same options as "Scored How?" — driving, stationary, both, or no passing.
+
+### Defense Skill (0-5)
+
+Rate how effectively the robot played defense (0 = no defense played).
+
+### Card
+
+| Option | Meaning |
+|--------|---------|
+| No Card | No penalty cards received |
+| Yellow | Yellow card issued |
+| Red | Red card issued |
+
+### Comments (Required)
+
+Write observations about the robot's performance. These are read by the strategy team during alliance selection.
+
+> [!TIP]
+> Good comments mention specific things: "Fast cycle time but struggled with ground pickup" is more useful than "Good robot."
+
+## Match Timer
+
+- The timer appears as a sticky header showing elapsed time (MM:SS)
+- Press **START** to begin, or it auto-starts on your first button press
+- Press **STOP** to pause, then **START** to resume
+- Press **RESET** to clear all data and start over
+
+## How Timeline Data Works
+
+Every button press creates a timeline entry stored in the format `code:type@time`:
+
+- `code` — The action code (e.g., `auto_score`, `tele_def`)
+- `type` — Either `start` (button pressed), `stop` (button released), or `point` (instant tap)
+- `time` — Seconds elapsed since the timer started
+
+**Example**: `auto_score:start@3;auto_score:stop@8;tele_fuel:point@45`
+
+This means: scoring started at 3 seconds, stopped at 8 seconds (5-second scoring action), then a fuel point was scored at 45 seconds.
+
+The timeline is submitted as a hidden form field and powers the Gantt chart visualizations on the dashboard.
+
+## Tips
+
+- **Hold buttons for the full duration** of the action, not just a tap
+- If you miss something, the timer keeps running — just pick up where you left off
+- Comments matter more than you think — the strategy team reads every one
+- If the robot dies early, mark "Died" and note it in comments
+- Don't worry about being perfect — some data is better than no data
+
+---
+
+See [Troubleshooting](troubleshooting.md) if the form isn't working properly.

--- a/static/docs/scouting-form.md
+++ b/static/docs/scouting-form.md
@@ -89,13 +89,6 @@ Same hold-to-time pattern with teleop-specific actions:
 | NEUTRAL ZONE | `tele_neutral` | Robot is in the neutral zone |
 | OPPONENT ZONE | `tele_opponent` | Robot is in the opponent zone |
 
-### Teleop Counters (Tap to Increment)
-
-| Button | Code | What to Track |
-|--------|------|---------------|
-| Fuel Scored | `tele_fuel` | Each fuel piece scored (tap once per piece) |
-| Fuel Fed | `tele_fed` | Each fuel piece fed to partner |
-
 ### Teleop Checkboxes
 
 - **Alliance won auto?** — Check if your alliance won the autonomous period

--- a/static/docs/setup-and-deployment.md
+++ b/static/docs/setup-and-deployment.md
@@ -1,0 +1,124 @@
+# Setup & Deployment
+
+> Get the scouting system running locally or deploy to production.
+
+[Back to docs index](README.md)
+
+## Prerequisites
+
+- **Node.js 18** or later
+- **npm** (included with Node.js)
+- **TBA API key** — [Register at thebluealliance.com](https://www.thebluealliance.com/account)
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+The dev server starts at `http://localhost:5173` (or next available port).
+
+## Environment Variables
+
+Create a `.env` file in the project root with these variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VITE_TBA_KEY` | Yes | — | The Blue Alliance API key |
+| `VITE_EVENT_KEY` | No | `2026rikin` | TBA event key for the competition |
+| `VITE_SCOUTING_CSV_URL` | Yes* | — | Published Google Sheets CSV URL for match scouting data |
+| `VITE_PIT_CSV_URL` | No | — | Published Google Sheets CSV URL for pit scouting data |
+| `VITE_SCOUTS_CSV_URL` | No | — | Published Google Sheets CSV URL for scout roster/availability |
+| `VITE_FILTER_TIME` | No | — | ISO timestamp to filter scouting data (e.g., `2026-03-28T09:00:00`) |
+| `VITE_PIT_SCOUTING_FORM_URL` | No | — | Google Form URL for pit scouting submissions |
+
+*Not required if using [debug mode](scouting-dashboard.md#debug-mode), which loads from test data.
+
+> [!IMPORTANT]
+> All variables must be prefixed with `VITE_` to be accessible in client-side code. Restart the dev server after changing `.env`.
+
+### Example `.env`
+
+```env
+VITE_TBA_KEY=your_tba_api_key_here
+VITE_EVENT_KEY=2026rikin
+VITE_SCOUTING_CSV_URL=https://docs.google.com/spreadsheets/d/SHEET_ID/export?format=csv&gid=0
+VITE_PIT_CSV_URL=https://docs.google.com/spreadsheets/d/SHEET_ID/export?format=csv&gid=123456
+VITE_SCOUTS_CSV_URL=https://docs.google.com/spreadsheets/d/SHEET_ID/export?format=csv&gid=789
+VITE_PIT_SCOUTING_FORM_URL=https://docs.google.com/forms/d/e/FORM_ID/viewform
+```
+
+## Google Sheets Setup
+
+The scouting form submits data to a Google Form, which populates a Google Sheet. To connect the dashboard:
+
+1. Open the Google Sheet that receives scouting form responses
+2. Go to **File > Share > Publish to web**
+3. Select the correct sheet tab and choose **CSV** format
+4. Click **Publish** and copy the URL
+5. Set `VITE_SCOUTING_CSV_URL` to this URL
+
+Repeat for pit scouting data (`VITE_PIT_CSV_URL`) and scout roster (`VITE_SCOUTS_CSV_URL`).
+
+> [!NOTE]
+> The published CSV URL auto-updates when new form responses come in. No manual re-publishing needed.
+
+## Building
+
+```bash
+npm run build
+npm run preview    # verify the production build locally
+```
+
+The build outputs to `./build` using SvelteKit's static adapter with a `404.html` fallback for client-side routing.
+
+## Deployment
+
+### Automatic (GitHub Actions)
+
+Push to the `next` branch to trigger automatic deployment to GitHub Pages.
+
+The workflow (`.github/workflows/AutoDeploy.yml`):
+1. Checks out the code
+2. Sets up Node.js 18
+3. Runs `npm ci` and `npm run build` with environment variables from GitHub Secrets
+4. Deploys the `build/` directory to GitHub Pages
+
+### GitHub Secrets
+
+These must be configured in the repository settings (Settings > Secrets and variables > Actions):
+
+| Secret | Maps To |
+|--------|---------|
+| `TBA_API_KEY` | `VITE_TBA_KEY` |
+| `EVENT_KEY` | `VITE_EVENT_KEY` |
+| `SCOUTING_CSV_URL` | `VITE_SCOUTING_CSV_URL` |
+| `PIT_CSV_URL` | `VITE_PIT_CSV_URL` |
+| `PIT_SCOUTING_FORM_URL` | `VITE_PIT_SCOUTING_FORM_URL` |
+| `SCOUTS_CSV_URL` | `VITE_SCOUTS_CSV_URL` |
+
+### Manual Deployment
+
+```bash
+npm run build
+npm run deploy    # pushes build/ to the deployment branch via gh-pages
+```
+
+## Updating for a New Season
+
+When preparing for a new competition season:
+
+- [ ] Update `VITE_EVENT_KEY` to the new event key (e.g., `2027txhou`)
+- [ ] Create new Google Forms and Sheets for the new season's game
+- [ ] Update scouting form fields if game mechanics change
+  - Form field `entry.*` IDs map to Google Form question IDs
+  - Action button codes (`auto_score`, `tele_def`, etc.) should match new game actions
+- [ ] Update starting position options in the form's `posMap` and select elements
+- [ ] Update test data files in `/static/test-data/` to match new game format
+- [ ] Update environment variables and GitHub Secrets
+- [ ] Verify the dashboard's RP prediction labels match the new season's ranking points
+
+---
+
+See [Architecture](architecture.md) for codebase details or [Troubleshooting](troubleshooting.md) for common issues.

--- a/static/docs/troubleshooting.md
+++ b/static/docs/troubleshooting.md
@@ -1,0 +1,139 @@
+# Troubleshooting
+
+> Common problems and how to fix them at a competition.
+
+[Back to docs index](README.md)
+
+## Scouting Form
+
+### Match data didn't load from TBA
+
+- Check your internet connection
+- Verify `VITE_TBA_KEY` is set and the API key is valid
+- Verify `VITE_EVENT_KEY` matches the current event
+- TBA may not have the schedule posted yet — check [thebluealliance.com](https://www.thebluealliance.com) directly
+
+### "Team is NOT in this match" warning
+
+- Double-check the match number and team number
+- The schedule may not be published yet on TBA
+- If you're sure the data is correct, continue scouting — the warning is informational
+
+### Timer started accidentally
+
+- Tap **STOP** to pause the timer
+- Tap **RESET** to clear all data and start fresh
+
+### Form won't submit
+
+- Check that all required fields are filled: scouter initials, match number, team number, and comments
+- Verify your internet connection (the form submits to Google Forms)
+- Try refreshing the page and re-entering the data
+
+### Hold buttons aren't registering
+
+- Make sure you're pressing and **holding**, not tapping
+- On mobile, avoid accidentally scrolling while holding a button
+- The timer must be running (started) for actions to record
+
+## Dashboard
+
+### Data not loading / stuck on loading screen
+
+- Check your internet connection
+- Verify `VITE_SCOUTING_CSV_URL` is a published Google Sheets link
+- Try **Quick Links > Debug — Quals** to test with sample data
+- Open browser console (F12) for specific error messages
+
+### Stale data showing
+
+- The dashboard caches data in your browser for up to 1 hour
+- **Hard refresh** (Ctrl+Shift+R on Windows, Cmd+Shift+R on Mac) to clear browser cache
+- Check that new form responses are actually appearing in the Google Sheet
+
+### Right-click context menu not appearing
+
+- **Desktop**: Right-click on a match cell in the Event Progress or Playoff Progress map
+- **Mobile**: Long-press (hold for about 1 second) on a match cell
+- Only works on **unplayed** matches — played matches show actual results
+
+### Bracket predictions look wrong
+
+- Check if actual alliance selections have been announced on TBA
+- Clear any manual overrides: right-click > "Clear Override" or use the "Clear Overrides" button
+- Predictions are based on EPA data — they may differ from your expectations
+
+### RP card tooltips not showing
+
+- Hover over the card with your mouse (desktop only)
+- The first three Win cards (duplicates) don't show tooltips — only the first Win card does
+- Tooltips require team EPA data to be loaded from Statbotics
+
+### Search/filter not working
+
+- Make sure you're typing a team number, not a team name
+- Clear the search bar to reset the filter
+
+## Scout Assignments
+
+### "No scouts loaded"
+
+- Verify `VITE_SCOUTS_CSV_URL` is set in your environment variables
+- Check that the Google Sheet is published as CSV (File > Share > Publish to web)
+- Verify the CSV has the expected column headers: `Scout Name`, `Start avail day 1`, etc.
+
+### Assignments not updating
+
+- Assignments are cached for 1 hour in localStorage
+- Click **Refresh** on the assignments page to regenerate
+- Manual clear: browser Developer Tools > Application > Local Storage > delete `scouting_assignments_cache`
+
+### Scout shows 0 assignments
+
+- Check that the scout's availability window covers the match times
+- The assignment algorithm checks match times against each scout's day 1 and day 2 availability
+
+## Debug Mode
+
+### Debug mode won't activate
+
+- Open Quick Links menu and click "Debug — Quals" or "Debug — Playoffs"
+- If the yellow banner doesn't appear, try refreshing the page
+
+### Can't exit debug mode
+
+- Click "Return to Live Dashboard" on the yellow warning banner
+- Or open Quick Links and click "Run Live Dashboard"
+- If neither works, clear localStorage and refresh the page
+
+### Debug data looks incomplete
+
+- "Debug — Quals" intentionally excludes playoff data (alliance selections and playoff matches)
+- Use "Debug — Playoffs" if you need the full dataset including playoff bracket data
+
+## Development
+
+### Build fails
+
+- Run `npm install` to ensure dependencies are current
+- Check Node.js version: `node --version` (requires Node 18+)
+- Run `npx svelte-kit sync` if type errors appear
+- Check for syntax errors in recently modified `.svelte` files
+
+### Environment variables not working
+
+- Variables must be prefixed with `VITE_` to be accessible in client code
+- **Restart the dev server** after changing `.env` — Vite doesn't hot-reload env changes
+- Check for typos in variable names
+
+### GitHub Actions deployment fails
+
+- Verify all required secrets are set in repository settings (Settings > Secrets and variables > Actions)
+- Check the workflow logs on the Actions tab for specific errors
+- The workflow requires: `TBA_API_KEY`, `EVENT_KEY`, `SCOUTING_CSV_URL`
+
+### Local dev server port conflict
+
+- If port 5173 is in use, Vite automatically tries 5174, 5175, etc.
+- Check the terminal output for the actual URL
+- Kill orphaned Node processes if ports are stuck: `npx kill-port 5173`


### PR DESCRIPTION
## Summary

- **9 comprehensive markdown docs** following [GitHub Docs best practices](https://docs.github.com/en/contributing/writing-for-github-docs/best-practices-for-github-docs) — plain language, scannable formatting, tables, callouts, cross-linking
- **Interactive docs viewer** bundled at `/docs/index.html` with GitHub-dark theme, sidebar navigation, and rendered markdown
- **Help Docs link** added to Quick Links menu on the scouting dashboard (opens in new tab)

## Documentation Pages

| Document | Audience | Content |
|----------|----------|---------|
| Competition Quick Start | Scouts | Print-friendly event day cheat sheet |
| Scouting Form Guide | Scouts | Every field, button, action code, and timeline format |
| Dashboard Guide | Strategy/Leads | All 7 modes, visual components, overrides, debug mode |
| Scout Assignments | Scout Leads | Setup, assignment algorithm, caching |
| Setup & Deployment | Developers | Env vars, Google Sheets setup, GitHub Actions |
| Architecture | Developers | Tech stack, project structure, data flow, component map |
| Data Format Reference | Developers | CSV schemas, timeline encoding, action codes, API contracts |
| Troubleshooting | Everyone | Common problems organized by page/feature |

## File Structure

- `docs/` — Source markdown files and index.html (for GitHub browsing)
- `static/docs/` — Same files served by the built site at `/docs/index.html`
- Quick Links "Help Docs" button → `/docs/index.html` (opens in new tab)

## Test plan
- [ ] Navigate to `/scouting-dashboard`, open Quick Links → "Help Docs" opens in new tab
- [ ] `/docs/index.html` renders the interactive viewer with sidebar navigation
- [ ] Click through all 8 doc pages in the sidebar — all render correctly
- [ ] Internal links between docs pages work (e.g., "See Troubleshooting" links)
- [ ] GitHub callouts (TIP, IMPORTANT, WARNING, NOTE) render with icons
- [ ] Docs are readable on mobile (responsive layout)
- [ ] `npm run build` → no errors, docs present in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)