### PR TITLE
Enhance Overview mode with data view, match times, and playoff fixes

### DIFF
--- a/src/routes/scouting-dashboard/+page.svelte
+++ b/src/routes/scouting-dashboard/+page.svelte
@@ -65,6 +65,7 @@
 	let simRedTeams = ['', '', ''];
 	let simBlueTeams = ['', '', ''];
 	let overviewTeam = '1757';
+	let overviewDataView = false;
 	let quickLinksOpen = false;
 	let isFullscreen = false;
 	let matchOverrides = new Map();
@@ -170,7 +171,7 @@
 		})
 		: allianceSimulation;
 
-	$: bracketSimulation = ((overrides) => {
+	$: bracketSimulation = ((overrides, _playoffs) => {
 		if (effectiveAlliances.length < 8) return null;
 
 		const getAllianceEPA = (alliance) => {
@@ -180,14 +181,16 @@
 		};
 
 		// Map set_number to playoff match for actual results lookup
+		// Only map semifinal matches (comp_level 'sf') by set_number
+		// Grand finals (comp_level 'f') are mapped separately to M14/M15
 		const playoffResultMap = new Map();
 		playoffSchedule.forEach(m => {
-			playoffResultMap.set(m.set_number, m);
-		});
-		// Grand finals: comp_level 'f' maps to M14
-		playoffSchedule.forEach(m => {
-			if (m.comp_level === 'f' && m.set_number === 1 && m.match_number === 1) {
-				playoffResultMap.set(14, m);
+			if (m.comp_level === 'f') {
+				// Grand finals match 1 → M14, match 2 → M15 (tiebreaker)
+				if (m.match_number === 1) playoffResultMap.set(14, m);
+				if (m.match_number === 2) playoffResultMap.set(15, m);
+			} else {
+				playoffResultMap.set(m.set_number, m);
 			}
 		});
 
@@ -301,7 +304,7 @@
 			tiebreaker: m15,
 			alliances: effectiveAlliances
 		};
-	})(playoffOverrides);
+	})(playoffOverrides, playoffSchedule);
 
 	function getWinProb(scoreDiff) {
 		const score_sd = yearStats?.score_sd || 20;
@@ -1221,21 +1224,90 @@
 			};
 		});
 
-	$: overviewTeamSchedule = overviewTeam ? schedule
-		.filter(m => teamIsInMatch(overviewTeam, m))
-		.map((m, idx, arr) => {
-			const isRed = m.alliances.red.team_keys.includes(`frc${overviewTeam}`);
-			const alliance = isRed ? 'red' : 'blue';
-			const nextMatch = arr[idx + 1];
-			let swapNeeded = false;
-			if (nextMatch) {
-				const nextIsRed = nextMatch.alliances.red.team_keys.includes(`frc${overviewTeam}`);
-				const nextAlliance = nextIsRed ? 'red' : 'blue';
-				swapNeeded = alliance !== nextAlliance;
-			}
-			const result = getMatchResult(m.match_number);
-			return { ...m, alliance, swapNeeded, isPlayed: !!result };
-		}) : [];
+	$: overviewTeamSchedule = (() => {
+		const enrichMatch = (m, team) => {
+			if (!m.alliances) return { ...m, alliance: null, swapNeeded: false, isPlayed: false, isPlayoff: false };
+			const isRed = team ? m.alliances.red.team_keys.includes(`frc${team}`) : false;
+			const alliance = team ? (isRed ? 'red' : 'blue') : null;
+			const redScore = m.alliances?.red?.score ?? -1;
+			const blueScore = m.alliances?.blue?.score ?? -1;
+			const isPlayed = redScore >= 0 && blueScore >= 0 && (redScore > 0 || blueScore > 0);
+			return { ...m, alliance, swapNeeded: false, isPlayed, isPlayoff: m.comp_level !== 'qm' };
+		};
+
+		if (!overviewTeam) {
+			const quals = schedule.map(m => enrichMatch(m, null));
+			return quals;
+		}
+
+		const teamQuals = schedule
+			.filter(m => teamIsInMatch(overviewTeam, m))
+			.map((m, idx, arr) => {
+				const isRed = m.alliances.red.team_keys.includes(`frc${overviewTeam}`);
+				const alliance = isRed ? 'red' : 'blue';
+				const nextMatch = arr[idx + 1];
+				let swapNeeded = false;
+				if (nextMatch) {
+					const nextIsRed = nextMatch.alliances.red.team_keys.includes(`frc${overviewTeam}`);
+					const nextAlliance = nextIsRed ? 'red' : 'blue';
+					swapNeeded = alliance !== nextAlliance;
+				}
+				const result = getMatchResult(m.match_number);
+				return { ...m, alliance, swapNeeded, isPlayed: !!result, isPlayoff: false };
+			});
+
+		// Add playoff matches if team is on an alliance
+		const playoffMatches = [];
+		const allianceIdx = getTeamPlayoffAllianceIndex(overviewTeam);
+		if (allianceIdx >= 0 && bracketSimulation) {
+			const teamAlliance = effectiveAlliances[allianceIdx];
+			const allianceNum = allianceIdx + 1;
+
+			// Check if an alliance object matches the team's alliance by index
+			const isTeamAlliance = (a) => {
+				if (!a) return false;
+				if (a === teamAlliance) return true;
+				// Fallback: compare by captain in case object identity differs
+				return a.captain === teamAlliance.captain;
+			};
+
+			bracketSimulation.matches.forEach(bm => {
+				if (!bm.a1 || !bm.a2) return;
+				const isA1 = isTeamAlliance(bm.a1);
+				const isA2 = isTeamAlliance(bm.a2);
+				if (!isA1 && !isA2) return;
+
+				const a1Teams = [bm.a1.captain, ...(bm.a1.picks || [])].map(t => `frc${t}`);
+				const a2Teams = [bm.a2.captain, ...(bm.a2.picks || [])].map(t => `frc${t}`);
+
+				// Look up TBA match for time data
+				const bmNum = parseInt(bm.label.replace('M', ''));
+				const tbaMatch = bmNum >= 14
+					? playoffSchedule.find(pm => pm.comp_level === 'f' && pm.match_number === (bmNum - 13))
+					: playoffSchedule.find(pm => pm.comp_level !== 'f' && pm.set_number === bmNum);
+
+				playoffMatches.push({
+					match_number: bm.label,
+					comp_level: 'sf',
+					alliances: {
+						red: { team_keys: a1Teams, score: bm.played ? (bm.redScore ?? null) : null },
+						blue: { team_keys: a2Teams, score: bm.played ? (bm.blueScore ?? null) : null }
+					},
+					alliance: isA1 ? 'red' : 'blue',
+					swapNeeded: false,
+					isPlayed: bm.played,
+					isPlayoff: true,
+					bracketMatch: bm,
+					playoffLabel: bm.label,
+					time: tbaMatch?.time,
+					predicted_time: tbaMatch?.predicted_time,
+					actual_time: tbaMatch?.actual_time
+				});
+			});
+		}
+
+		return [...teamQuals, ...playoffMatches];
+	})();
 
 	$: sortedLeaderboard = [...teamMetrics].sort((a, b) => {
 		let valA, valB;
@@ -1688,6 +1760,88 @@
 
 	function clearPlayoffOverrides() {
 		playoffOverrides = new Map();
+	}
+
+	function formatMatchTime(unixSeconds) {
+		if (!unixSeconds) return null;
+		const d = new Date(unixSeconds * 1000);
+		const day = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+		const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+		return `${day} ${time}`;
+	}
+
+	function getOverviewMatchPrediction(match) {
+		const redTeams = (match.alliances?.red?.team_keys || []).map(k => k.replace('frc', ''));
+		const blueTeams = (match.alliances?.blue?.team_keys || []).map(k => k.replace('frc', ''));
+		const redEpa = redTeams.reduce((s, t) => s + (teamStatsMap.get(t)?.epa || 0), 0);
+		const blueEpa = blueTeams.reduce((s, t) => s + (teamStatsMap.get(t)?.epa || 0), 0);
+		const winProb = getWinProb(redEpa - blueEpa);
+
+		const redScore = match.alliances?.red?.score ?? -1;
+		const blueScore = match.alliances?.blue?.score ?? -1;
+		const played = redScore >= 0 && blueScore >= 0 && (redScore > 0 || blueScore > 0);
+		const winner = played ? (redScore > blueScore ? 'red' : blueScore > redScore ? 'blue' : 'tie') : null;
+
+		function allianceRp(teams) {
+			let rp1Sum = 0, rp2Sum = 0, rp3Sum = 0;
+			const details = { rp1: [], rp2: [], rp3: [] };
+			teams.forEach(t => {
+				const stats = teamStatsMap.get(t);
+				const v1 = stats?.rp1 || 0, v2 = stats?.rp2 || 0, v3 = stats?.rp3 || 0;
+				rp1Sum += v1; rp2Sum += v2; rp3Sum += v3;
+				details.rp1.push({ team: t, value: v1 });
+				details.rp2.push({ team: t, value: v2 });
+				details.rp3.push({ team: t, value: v3 });
+			});
+			const rpSt = (sum) => sum > 1.0 ? 'lit' : sum > 0.8 ? 'contention' : 'muted';
+			const rpLbl = (sum) => sum > 1.0 ? 'Likely (>1.0)' : sum > 0.8 ? 'Possible (>0.8)' : 'Unlikely (\u22640.8)';
+			return {
+				rp1: rpSt(rp1Sum), rp2: rpSt(rp2Sum), rp3: rpSt(rp3Sum),
+				reasons: {
+					rp1: { teams: details.rp1, sum: rp1Sum, label: rpLbl(rp1Sum) },
+					rp2: { teams: details.rp2, sum: rp2Sum, label: rpLbl(rp2Sum) },
+					rp3: { teams: details.rp3, sum: rp3Sum, label: rpLbl(rp3Sum) },
+				}
+			};
+		}
+
+		const rpRed = allianceRp(redTeams);
+		const rpBlue = allianceRp(blueTeams);
+
+		if (played) {
+			rpRed.win = winner === 'red' ? 'lit' : 'muted';
+			rpRed.reasons.win = { winProb: winner === 'red' ? 1 : 0, label: winner === 'red' ? 'Won' : 'Lost' };
+			rpBlue.win = winner === 'blue' ? 'lit' : 'muted';
+			rpBlue.reasons.win = { winProb: winner === 'blue' ? 1 : 0, label: winner === 'blue' ? 'Won' : 'Lost' };
+		} else {
+			const winSt = (prob) => prob > 0.625 ? 'lit' : prob < 0.375 ? 'muted' : 'contention';
+			const winLbl = (prob) => prob > 0.625 ? 'Likely (>62.5%)' : prob < 0.375 ? 'Unlikely (<37.5%)' : 'Toss-up';
+			rpRed.win = winSt(winProb);
+			rpRed.reasons.win = { winProb, label: winLbl(winProb) };
+			rpBlue.win = winSt(1 - winProb);
+			rpBlue.reasons.win = { winProb: 1 - winProb, label: winLbl(1 - winProb) };
+		}
+
+		return { winProb, redEpa, blueEpa, played, winner, redScore, blueScore, rpRed, rpBlue };
+	}
+
+	function getTeamWarnings(teamNum) {
+		const issues = getMatchesWithIssues(teamNum);
+		const cardMatches = scoutingData.filter(r => getVal(r, 'Team #') === teamNum && getVal(r, 'card') && getVal(r, 'card') !== 'No Card' && getVal(r, 'card') !== 'N/A' && getVal(r, 'card') !== '');
+		const hasYellow = cardMatches.some(r => getVal(r, 'card') === 'Yellow');
+		const hasRed = cardMatches.some(r => getVal(r, 'card') === 'Red');
+		const cardCount = cardMatches.length;
+		const diedCount = issues.filter(i => i.hasDied).length;
+		const mechCount = issues.filter(i => i.hasMechanical).length;
+		const tippedCount = issues.filter(i => i.hasTipped).length;
+		return { cardCount, diedCount, mechCount, tippedCount, hasYellow, hasRed };
+	}
+
+	function getTeamPlayoffAllianceIndex(teamNum) {
+		if (!effectiveAlliances || effectiveAlliances.length === 0) return -1;
+		return effectiveAlliances.findIndex(a =>
+			a.captain === teamNum || (a.picks && a.picks.includes(teamNum)) || (a.allPicks && a.allPicks.includes(teamNum))
+		);
 	}
 
 	function enterDebugMode(mode) {
@@ -3352,22 +3506,94 @@
 					<div class="w-full md:w-80 flex-shrink-0">
 						<div class="bg-zinc-900/40 border-2 border-purple-500/20 rounded-3xl p-6 backdrop-blur-xl shadow-2xl sticky top-4">
 							<h3 class="text-xl font-black text-purple-400 uppercase italic tracking-tighter mb-4">Team Focus</h3>
-							<div class="relative mb-6">
-								<input 
-									type="text" 
-									bind:value={overviewTeam} 
-									placeholder="Enter Team #..." 
+							<div class="relative mb-4">
+								<input
+									type="text"
+									bind:value={overviewTeam}
+									placeholder="Enter Team # or leave blank for all..."
 									class="w-full bg-black/40 border-2 border-zinc-800 rounded-xl p-4 font-black text-white focus:border-purple-500 outline-none transition uppercase"
 								/>
 							</div>
-							
+
+							<!-- Data View Toggle -->
+							<div class="flex rounded-xl overflow-hidden border-2 border-zinc-800 mb-4">
+								<button on:click={() => overviewDataView = false} class="flex-1 py-2 text-[9px] font-black uppercase tracking-widest transition {!overviewDataView ? 'bg-purple-600 text-white' : 'bg-black/40 text-zinc-500 hover:text-white'}">Schedule</button>
+								<button on:click={() => overviewDataView = true} class="flex-1 py-2 text-[9px] font-black uppercase tracking-widest transition {overviewDataView ? 'bg-purple-600 text-white' : 'bg-black/40 text-zinc-500 hover:text-white'}">Data View</button>
+							</div>
+
 							{#if overviewTeam}
 								{@const details = teamDetailsMap.get(overviewTeam)}
+								{@const stats = teamStatsMap.get(overviewTeam)}
+								{@const opr = eventOprs?.[`frc${overviewTeam}`] || 0}
 								<div class="space-y-4">
 									<div class="p-4 bg-purple-500/5 border border-purple-500/20 rounded-2xl">
 										<p class="text-3xl font-black text-white">{overviewTeam}</p>
 										<p class="text-xs font-black text-zinc-500 uppercase tracking-widest truncate">{details?.nickname || 'Unknown Team'}</p>
 									</div>
+
+									{#if overviewDataView && stats}
+										{@const eventRank = eventRankings.find(r => r.team_key === `frc${overviewTeam}`)?.rank}
+										<!-- Team Performance Stats -->
+										<div class="space-y-2">
+											<div class="grid grid-cols-2 gap-2">
+												<div class="p-3 bg-blue-500/5 border border-blue-500/20 rounded-xl">
+													<p class="text-[8px] font-black text-blue-400 uppercase tracking-widest">EPA</p>
+													<p class="text-xl font-black text-white">{stats.epa.toFixed(1)}</p>
+												</div>
+												<div class="p-3 bg-green-500/5 border border-green-500/20 rounded-xl">
+													<p class="text-[8px] font-black text-green-400 uppercase tracking-widest">OPR</p>
+													<p class="text-xl font-black text-white">{opr.toFixed(1)}</p>
+												</div>
+											</div>
+											{#each [overviewTeamSchedule.filter(m2 => m2.isPlayed)] as wl}
+												{@const wins = wl.filter(m2 => {
+													const rs = m2.alliances?.red?.score ?? 0;
+													const bs = m2.alliances?.blue?.score ?? 0;
+													return (m2.alliance === 'red' && rs > bs) || (m2.alliance === 'blue' && bs > rs);
+												}).length}
+												<div class="grid grid-cols-2 gap-2">
+													<div class="p-3 bg-orange-500/5 border border-orange-500/20 rounded-xl">
+														<p class="text-[8px] font-black text-orange-400 uppercase tracking-widest">Event Rank</p>
+														<p class="text-xl font-black text-white">{eventRank ? `#${eventRank}` : '—'}</p>
+													</div>
+													<div class="p-3 bg-purple-500/5 border border-purple-500/20 rounded-xl">
+														<p class="text-[8px] font-black text-purple-400 uppercase tracking-widest">Record</p>
+														<p class="text-xl font-black text-white">{wins}-{wl.length - wins}</p>
+													</div>
+												</div>
+											{/each}
+											<div class="p-3 bg-zinc-800/50 border border-zinc-700 rounded-xl">
+												<p class="text-[8px] font-black text-zinc-400 uppercase tracking-widest mb-2">RP Rates</p>
+												<div class="grid grid-cols-3 gap-2 text-center">
+													<div>
+														<p class="text-xs font-black text-white">{(stats.rp1 || 0).toFixed(2)}</p>
+														<p class="text-[7px] text-zinc-500 font-bold">RP1</p>
+													</div>
+													<div>
+														<p class="text-xs font-black text-white">{(stats.rp2 || 0).toFixed(2)}</p>
+														<p class="text-[7px] text-zinc-500 font-bold">RP2</p>
+													</div>
+													<div>
+														<p class="text-xs font-black text-white">{(stats.rp3 || 0).toFixed(2)}</p>
+														<p class="text-[7px] text-zinc-500 font-bold">RP3</p>
+													</div>
+												</div>
+											</div>
+											{#each [getTeamWarnings(overviewTeam)] as teamWarn}
+												{#if teamWarn.cardCount > 0 || teamWarn.diedCount > 0 || teamWarn.mechCount > 0 || teamWarn.tippedCount > 0}
+													<div class="p-3 bg-red-500/5 border border-red-500/20 rounded-xl">
+														<p class="text-[8px] font-black text-red-400 uppercase tracking-widest mb-1">Issues</p>
+														<div class="space-y-0.5 text-[10px] text-red-300">
+															{#if teamWarn.cardCount > 0}<p>{teamWarn.hasRed ? 'Red' : 'Yellow'} carded ({teamWarn.cardCount}x)</p>{/if}
+															{#if teamWarn.diedCount > 0}<p>Died in {teamWarn.diedCount} match{teamWarn.diedCount > 1 ? 'es' : ''}</p>{/if}
+															{#if teamWarn.mechCount > 0}<p>Mech issue in {teamWarn.mechCount} match{teamWarn.mechCount > 1 ? 'es' : ''}</p>{/if}
+															{#if teamWarn.tippedCount > 0}<p>Tipped in {teamWarn.tippedCount} match{teamWarn.tippedCount > 1 ? 'es' : ''}</p>{/if}
+														</div>
+													</div>
+												{/if}
+											{/each}
+										</div>
+									{/if}
 								</div>
 							{/if}
 						</div>
@@ -3375,66 +3601,85 @@
 
 					<!-- Schedule & Status -->
 					<div class="flex-1">
-						{#if !overviewTeam}
+						{#if overviewTeamSchedule.length === 0}
 							<div class="h-64 flex flex-col items-center justify-center bg-zinc-900/20 rounded-[2.5rem] border-2 border-zinc-800 border-dashed">
-								<p class="text-zinc-600 font-black uppercase tracking-[0.2em]">Select a team to view schedule</p>
-							</div>
-						{:else if overviewTeamSchedule.length === 0}
-							<div class="h-64 flex flex-col items-center justify-center bg-zinc-900/20 rounded-[2.5rem] border-2 border-zinc-800 border-dashed">
-								<p class="text-zinc-600 font-black uppercase tracking-[0.2em]">No matches found for Team {overviewTeam}</p>
+								<p class="text-zinc-600 font-black uppercase tracking-[0.2em]">{overviewTeam ? `No matches found for Team ${overviewTeam}` : 'No schedule data available'}</p>
 							</div>
 						{:else}
+							{#if !overviewTeam}
+								<p class="text-[10px] font-black text-zinc-500 uppercase tracking-widest mb-3">Full Event Schedule ({overviewTeamSchedule.length} matches)</p>
+							{/if}
 							<div class="grid grid-cols-1 gap-4">
 								{#each overviewTeamSchedule as m}
-									<div 
-										on:click={() => selectedMatchPopup = m}
-										role="button"
-										tabindex="0"
-										on:keydown={(e) => e.key === 'Enter' && (selectedMatchPopup = m)}
-										class="group bg-zinc-900/40 border-2 {m.alliance === 'red' ? 'border-red-500/20 hover:border-red-500/40' : 'border-blue-500/20 hover:border-blue-500/40'} rounded-[2rem] p-6 backdrop-blur-xl shadow-xl transition-all relative overflow-hidden cursor-pointer">
+									{@const pred = overviewDataView ? getOverviewMatchPrediction(m) : null}
+									{@const allianceBorder = m.alliance === 'red' ? 'border-red-500/20 hover:border-red-500/40' : m.alliance === 'blue' ? 'border-blue-500/20 hover:border-blue-500/40' : 'border-zinc-700 hover:border-zinc-600'}
+									<div
+										class="group bg-zinc-900/40 border-2 {allianceBorder} rounded-[2rem] p-6 backdrop-blur-xl shadow-xl transition-all relative overflow-hidden">
 
-										<div class="flex flex-col md:flex-row justify-between items-center gap-6 relative z-10">
-											<div class="flex items-center gap-6">
-												<div class="w-20 h-20 rounded-2xl flex flex-col items-center justify-center {m.alliance === 'red' ? 'bg-red-500/10 border-2 border-red-500/20' : 'bg-blue-500/10 border-2 border-blue-500/20'}">
-													<p class="text-[10px] font-black {m.alliance === 'red' ? 'text-red-500' : 'text-blue-500'} uppercase">Match</p>
-													<p class="text-3xl font-black text-white">{m.match_number}</p>
+										<div class="flex flex-col md:flex-row justify-between items-start gap-6 relative z-10">
+											<div class="flex items-start gap-6 flex-1">
+												<div class="w-20 h-20 rounded-2xl flex flex-col items-center justify-center flex-shrink-0 {m.alliance === 'red' ? 'bg-red-500/10 border-2 border-red-500/20' : m.alliance === 'blue' ? 'bg-blue-500/10 border-2 border-blue-500/20' : 'bg-zinc-800 border-2 border-zinc-700'}">
+													<p class="text-[10px] font-black {m.alliance === 'red' ? 'text-red-500' : m.alliance === 'blue' ? 'text-blue-500' : 'text-zinc-400'} uppercase">{m.isPlayoff ? m.playoffLabel || m.match_number : 'Match'}</p>
+													<p class="text-3xl font-black text-white">{m.isPlayoff ? '' : m.match_number}</p>
 												</div>
-												<div>
+												<div class="flex-1">
 													<div class="flex items-center gap-3 mb-3">
+														{#if m.isPlayoff}
+															<span class="text-[10px] font-black text-orange-400 uppercase tracking-widest">Playoff</span>
+														{/if}
 														{#if m.isPlayed}
 															<span class="text-[10px] font-black text-green-500 uppercase tracking-widest flex items-center gap-1">
 																<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" /></svg>
 																Played
 															</span>
+															{#if pred}
+																<span class="text-[10px] font-black text-zinc-400">{pred.redScore} - {pred.blueScore}</span>
+															{/if}
 														{:else}
 															<span class="text-[10px] font-black text-zinc-500 uppercase tracking-widest">Upcoming</span>
+															{#if pred}
+																<span class="text-[10px] font-bold {pred.winProb > 0.5 ? 'text-red-400' : 'text-blue-400'}">{(Math.max(pred.winProb, 1 - pred.winProb) * 100).toFixed(0)}% {pred.winProb > 0.5 ? 'Red' : 'Blue'}</span>
+															{/if}
 														{/if}
 													</div>
-													
+
+													{#if m.time || m.predicted_time}
+														<div class="flex items-center gap-3 mb-3 text-[10px] text-zinc-500">
+															{#if m.time}
+																<span class="flex items-center gap-1">
+																	<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+																	<span class="font-bold">Scheduled:</span> {formatMatchTime(m.time)}
+																</span>
+															{/if}
+															{#if m.predicted_time && m.predicted_time !== m.time}
+																<span class="flex items-center gap-1 {m.predicted_time > m.time ? 'text-yellow-500/70' : 'text-zinc-500'}">
+																	<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
+																	<span class="font-bold">Predicted:</span> {formatMatchTime(m.predicted_time)}
+																</span>
+															{/if}
+														</div>
+													{/if}
 													<div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
-														<!-- Playing With -->
 														<div>
-															<p class="text-[8px] font-black text-zinc-500 uppercase tracking-widest mb-1.5">Red Alliance</p>
+															<p class="text-[8px] font-black text-red-500/60 uppercase tracking-widest mb-1.5">Red Alliance {pred ? `(${pred.redEpa.toFixed(0)} EPA)` : ''}</p>
 															<div class="grid grid-cols-3 gap-2">
-																{#each m.alliances['red'].team_keys as key}
+																{#each (m.alliances?.red?.team_keys || []) as key}
 																	{@const tNum = key.replace('frc', '')}
-																	<button 
-																		on:click|stopPropagation={() => handleRowClick({ 'Team #': tNum })}
+																	<button
+																		on:click|stopPropagation={() => { overviewTeam = tNum; }}
 																		class="px-3 py-1.5 rounded-lg text-sm font-black {tNum === overviewTeam ? 'bg-purple-600 text-white border-purple-400 shadow-[0_0_15px_rgba(168,85,247,0.3)]' : 'bg-black/40 text-zinc-300 hover:bg-zinc-800 hover:text-white border-white/5'} border transition-all text-center whitespace-nowrap">
 																		{tNum}
 																	</button>
 																{/each}
 															</div>
 														</div>
-														
-														<!-- Playing Against -->
 														<div>
-															<p class="text-[8px] font-black text-zinc-500 uppercase tracking-widest mb-1.5">Blue Alliance</p>
+															<p class="text-[8px] font-black text-blue-500/60 uppercase tracking-widest mb-1.5">Blue Alliance {pred ? `(${pred.blueEpa.toFixed(0)} EPA)` : ''}</p>
 															<div class="grid grid-cols-3 gap-2">
-																{#each m.alliances['blue'].team_keys as key}
+																{#each (m.alliances?.blue?.team_keys || []) as key}
 																	{@const tNum = key.replace('frc', '')}
-																	<button 
-																		on:click|stopPropagation={() => handleRowClick({ 'Team #': tNumOpp })}
+																	<button
+																		on:click|stopPropagation={() => { overviewTeam = tNum; }}
 																		class="px-3 py-1.5 rounded-lg text-sm font-black {tNum === overviewTeam ? 'bg-purple-600 text-white border-purple-400 shadow-[0_0_15px_rgba(168,85,247,0.3)]' : 'bg-black/40 text-zinc-300 hover:bg-zinc-800 hover:text-white border-white/5'} border transition-all text-center whitespace-nowrap">
 																		{tNum}
 																	</button>
@@ -3442,24 +3687,83 @@
 															</div>
 														</div>
 													</div>
+
+													<!-- Data View: RP Cards & Warnings -->
+													{#if overviewDataView && pred && m.alliances}
+														<div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
+															<div>
+																<p class="text-[7px] font-black text-red-500/50 uppercase tracking-widest mb-1">Red RP Projection</p>
+																<RPCards alliance="red" predictions={pred.rpRed} />
+															</div>
+															<div>
+																<p class="text-[7px] font-black text-blue-500/50 uppercase tracking-widest mb-1">Blue RP Projection</p>
+																<RPCards alliance="blue" predictions={pred.rpBlue} />
+															</div>
+														</div>
+
+														<!-- Win Probability Bar -->
+														{#if !pred.played}
+															<div class="mt-2 mb-1">
+																<div class="flex h-2 rounded-full overflow-hidden">
+																	<div class="bg-red-500 transition-all" style="width: {pred.winProb * 100}%"></div>
+																	<div class="bg-blue-500 transition-all" style="width: {(1 - pred.winProb) * 100}%"></div>
+																</div>
+															</div>
+														{/if}
+
+														<!-- Alliance Partner Warnings -->
+														{#if overviewTeam}
+															{@const allianceKeys = m.alliance === 'red' ? (m.alliances.red?.team_keys || []) : (m.alliances.blue?.team_keys || [])}
+															{@const partnerWarnings = allianceKeys.map(k => ({ team: k.replace('frc', ''), warnings: getTeamWarnings(k.replace('frc', '')) })).filter(pw => pw.team !== overviewTeam && (pw.warnings.cardCount > 0 || pw.warnings.diedCount > 0 || pw.warnings.mechCount > 0 || pw.warnings.tippedCount > 0))}
+															{#if partnerWarnings.length > 0}
+																<div class="mt-3 space-y-1.5">
+																	{#each partnerWarnings as pw}
+																		<div class="flex items-start gap-2 text-[10px] bg-yellow-500/5 border border-yellow-500/20 rounded-lg px-3 py-2">
+																			<span class="text-yellow-400 flex-shrink-0">⚠</span>
+																			<div class="text-yellow-300/90">
+																				{#if pw.warnings.cardCount > 0}
+																					<p><span class="font-black">Team {pw.team}</span> has been {pw.warnings.hasRed ? 'red' : 'yellow'} carded during quals</p>
+																				{/if}
+																				{#if pw.warnings.diedCount > 0}
+																					<p><span class="font-black">Team {pw.team}</span> has died in {pw.warnings.diedCount} previous match{pw.warnings.diedCount > 1 ? 'es' : ''}</p>
+																				{/if}
+																				{#if pw.warnings.mechCount > 0}
+																					<p><span class="font-black">Team {pw.team}</span> has broken down in {pw.warnings.mechCount} previous match{pw.warnings.mechCount > 1 ? 'es' : ''}</p>
+																				{/if}
+																				{#if pw.warnings.tippedCount > 0}
+																					<p><span class="font-black">Team {pw.team}</span> has tipped in {pw.warnings.tippedCount} previous match{pw.warnings.tippedCount > 1 ? 'es' : ''}</p>
+																				{/if}
+																			</div>
+																		</div>
+																	{/each}
+																</div>
+															{/if}
+														{/if}
+													{/if}
 												</div>
 											</div>
 
-											<div class="flex flex-col items-end gap-3">
-												{#if m.swapNeeded}
-													<div class="flex items-center gap-2 text-orange-400">
-														<svg class="w-5 h-5 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
-														<span class="text-xs font-black uppercase tracking-widest">Bumper Swap After Match</span>
-													</div>
+											<div class="flex flex-col items-end gap-3 flex-shrink-0">
+												{#if !m.isPlayoff}
+													<button
+														on:click|stopPropagation={() => loadMatchIntoSimulator(m)}
+														class="bg-zinc-800 hover:bg-purple-600 text-white text-[10px] font-black px-6 py-3 rounded-xl transition-all uppercase tracking-[0.2em] shadow-lg active:scale-95 border border-zinc-700">
+														Simulate
+													</button>
 												{/if}
-												<button 
-													on:click|stopPropagation={() => loadMatchIntoSimulator(m)}
-													class="bg-zinc-800 hover:bg-purple-600 text-white text-[10px] font-black px-6 py-3 rounded-xl transition-all uppercase tracking-[0.2em] shadow-lg active:scale-95 border border-zinc-700">
-													Load Into Simulator
-												</button>
 											</div>
 										</div>
 									</div>
+									{#if m.swapNeeded}
+										<div class="flex items-center justify-center gap-3 py-2">
+											<div class="flex-1 border-t border-dashed border-orange-500/30"></div>
+											<div class="flex items-center gap-2 text-orange-400 bg-orange-500/5 border border-orange-500/20 rounded-full px-4 py-1.5">
+												<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
+												<span class="text-[10px] font-black uppercase tracking-widest">Bumper Swap</span>
+											</div>
+											<div class="flex-1 border-t border-dashed border-orange-500/30"></div>
+										</div>
+									{/if}
 								{/each}
 							</div>
 						{/if}

--- a/static/test-data/playoff-schedule.json
+++ b/static/test-data/playoff-schedule.json
@@ -5,10 +5,27 @@
     "set_number": 1,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc78", "frc6620", "frc1757"], "score": 185 },
-      "blue": { "team_keys": ["frc1699", "frc10063", "frc2079"], "score": 142 }
+      "red": {
+        "team_keys": [
+          "frc78",
+          "frc6620",
+          "frc1757"
+        ],
+        "score": 185
+      },
+      "blue": {
+        "team_keys": [
+          "frc1699",
+          "frc10063",
+          "frc2079"
+        ],
+        "score": 142
+      }
     },
-    "winning_alliance": "red"
+    "winning_alliance": "red",
+    "time": 1774900800,
+    "predicted_time": 1774900800,
+    "actual_time": 1774900815
   },
   {
     "key": "2026rikin_sf2_1",
@@ -16,10 +33,27 @@
     "set_number": 2,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc6324", "frc6367", "frc10254"], "score": 171 },
-      "blue": { "team_keys": ["frc10973", "frc5112", "frc6333"], "score": 158 }
+      "red": {
+        "team_keys": [
+          "frc6324",
+          "frc6367",
+          "frc10254"
+        ],
+        "score": 171
+      },
+      "blue": {
+        "team_keys": [
+          "frc10973",
+          "frc5112",
+          "frc6333"
+        ],
+        "score": 158
+      }
     },
-    "winning_alliance": "red"
+    "winning_alliance": "red",
+    "time": 1774901400,
+    "predicted_time": 1774901445,
+    "actual_time": 1774901460
   },
   {
     "key": "2026rikin_sf3_1",
@@ -27,10 +61,27 @@
     "set_number": 3,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc2168", "frc1768", "frc5000"], "score": 192 },
-      "blue": { "team_keys": ["frc3623", "frc1153", "frc1735"], "score": 134 }
+      "red": {
+        "team_keys": [
+          "frc2168",
+          "frc1768",
+          "frc5000"
+        ],
+        "score": 192
+      },
+      "blue": {
+        "team_keys": [
+          "frc3623",
+          "frc1153",
+          "frc1735"
+        ],
+        "score": 134
+      }
     },
-    "winning_alliance": "red"
+    "winning_alliance": "red",
+    "time": 1774902000,
+    "predicted_time": 1774902090,
+    "actual_time": 1774902105
   },
   {
     "key": "2026rikin_sf4_1",
@@ -38,10 +89,27 @@
     "set_number": 4,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc3719", "frc4176", "frc663"], "score": 145 },
-      "blue": { "team_keys": ["frc10066", "frc1350", "frc61"], "score": 162 }
+      "red": {
+        "team_keys": [
+          "frc3719",
+          "frc4176",
+          "frc663"
+        ],
+        "score": 145
+      },
+      "blue": {
+        "team_keys": [
+          "frc10066",
+          "frc1350",
+          "frc61"
+        ],
+        "score": 162
+      }
     },
-    "winning_alliance": "blue"
+    "winning_alliance": "blue",
+    "time": 1774902600,
+    "predicted_time": 1774902735,
+    "actual_time": 1774902750
   },
   {
     "key": "2026rikin_sf5_1",
@@ -49,10 +117,27 @@
     "set_number": 5,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc1699", "frc10063", "frc2079"], "score": 131 },
-      "blue": { "team_keys": ["frc10973", "frc5112", "frc6333"], "score": 148 }
+      "red": {
+        "team_keys": [
+          "frc1699",
+          "frc10063",
+          "frc2079"
+        ],
+        "score": 131
+      },
+      "blue": {
+        "team_keys": [
+          "frc10973",
+          "frc5112",
+          "frc6333"
+        ],
+        "score": 148
+      }
     },
-    "winning_alliance": "blue"
+    "winning_alliance": "blue",
+    "time": 1774903200,
+    "predicted_time": 1774903380,
+    "actual_time": 1774903395
   },
   {
     "key": "2026rikin_sf6_1",
@@ -60,10 +145,27 @@
     "set_number": 6,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc3623", "frc1153", "frc1735"], "score": 139 },
-      "blue": { "team_keys": ["frc3719", "frc4176", "frc663"], "score": 156 }
+      "red": {
+        "team_keys": [
+          "frc3623",
+          "frc1153",
+          "frc1735"
+        ],
+        "score": 139
+      },
+      "blue": {
+        "team_keys": [
+          "frc3719",
+          "frc4176",
+          "frc663"
+        ],
+        "score": 156
+      }
     },
-    "winning_alliance": "blue"
+    "winning_alliance": "blue",
+    "time": 1774903800,
+    "predicted_time": 1774904025,
+    "actual_time": 1774904040
   },
   {
     "key": "2026rikin_sf7_1",
@@ -71,10 +173,27 @@
     "set_number": 7,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc78", "frc6620", "frc1757"], "score": 201 },
-      "blue": { "team_keys": ["frc6324", "frc6367", "frc10254"], "score": 167 }
+      "red": {
+        "team_keys": [
+          "frc78",
+          "frc6620",
+          "frc1757"
+        ],
+        "score": 201
+      },
+      "blue": {
+        "team_keys": [
+          "frc6324",
+          "frc6367",
+          "frc10254"
+        ],
+        "score": 167
+      }
     },
-    "winning_alliance": "red"
+    "winning_alliance": "red",
+    "time": 1774904400,
+    "predicted_time": 1774904670,
+    "actual_time": 1774904685
   },
   {
     "key": "2026rikin_sf8_1",
@@ -82,10 +201,27 @@
     "set_number": 8,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc2168", "frc1768", "frc5000"], "score": 178 },
-      "blue": { "team_keys": ["frc10066", "frc1350", "frc61"], "score": 155 }
+      "red": {
+        "team_keys": [
+          "frc2168",
+          "frc1768",
+          "frc5000"
+        ],
+        "score": 178
+      },
+      "blue": {
+        "team_keys": [
+          "frc10066",
+          "frc1350",
+          "frc61"
+        ],
+        "score": 155
+      }
     },
-    "winning_alliance": "red"
+    "winning_alliance": "red",
+    "time": 1774905000,
+    "predicted_time": 1774905315,
+    "actual_time": 1774905330
   },
   {
     "key": "2026rikin_sf9_1",
@@ -93,10 +229,26 @@
     "set_number": 9,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc10066", "frc1350", "frc61"], "score": -1 },
-      "blue": { "team_keys": ["frc10973", "frc5112", "frc6333"], "score": -1 }
+      "red": {
+        "team_keys": [
+          "frc10066",
+          "frc1350",
+          "frc61"
+        ],
+        "score": -1
+      },
+      "blue": {
+        "team_keys": [
+          "frc10973",
+          "frc5112",
+          "frc6333"
+        ],
+        "score": -1
+      }
     },
-    "winning_alliance": ""
+    "winning_alliance": "",
+    "time": 1774905600,
+    "predicted_time": 1774905960
   },
   {
     "key": "2026rikin_sf10_1",
@@ -104,10 +256,26 @@
     "set_number": 10,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc6324", "frc6367", "frc10254"], "score": -1 },
-      "blue": { "team_keys": ["frc3719", "frc4176", "frc663"], "score": -1 }
+      "red": {
+        "team_keys": [
+          "frc6324",
+          "frc6367",
+          "frc10254"
+        ],
+        "score": -1
+      },
+      "blue": {
+        "team_keys": [
+          "frc3719",
+          "frc4176",
+          "frc663"
+        ],
+        "score": -1
+      }
     },
-    "winning_alliance": ""
+    "winning_alliance": "",
+    "time": 1774906200,
+    "predicted_time": 1774906605
   },
   {
     "key": "2026rikin_sf11_1",
@@ -115,10 +283,26 @@
     "set_number": 11,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": ["frc78", "frc6620", "frc1757"], "score": -1 },
-      "blue": { "team_keys": ["frc2168", "frc1768", "frc5000"], "score": -1 }
+      "red": {
+        "team_keys": [
+          "frc78",
+          "frc6620",
+          "frc1757"
+        ],
+        "score": -1
+      },
+      "blue": {
+        "team_keys": [
+          "frc2168",
+          "frc1768",
+          "frc5000"
+        ],
+        "score": -1
+      }
     },
-    "winning_alliance": ""
+    "winning_alliance": "",
+    "time": 1774906800,
+    "predicted_time": 1774907250
   },
   {
     "key": "2026rikin_sf12_1",
@@ -126,10 +310,18 @@
     "set_number": 12,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": [], "score": -1 },
-      "blue": { "team_keys": [], "score": -1 }
+      "red": {
+        "team_keys": [],
+        "score": -1
+      },
+      "blue": {
+        "team_keys": [],
+        "score": -1
+      }
     },
-    "winning_alliance": ""
+    "winning_alliance": "",
+    "time": 1774907400,
+    "predicted_time": 1774907895
   },
   {
     "key": "2026rikin_sf13_1",
@@ -137,10 +329,18 @@
     "set_number": 13,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": [], "score": -1 },
-      "blue": { "team_keys": [], "score": -1 }
+      "red": {
+        "team_keys": [],
+        "score": -1
+      },
+      "blue": {
+        "team_keys": [],
+        "score": -1
+      }
     },
-    "winning_alliance": ""
+    "winning_alliance": "",
+    "time": 1774908000,
+    "predicted_time": 1774908540
   },
   {
     "key": "2026rikin_f1_1",
@@ -148,9 +348,17 @@
     "set_number": 1,
     "match_number": 1,
     "alliances": {
-      "red": { "team_keys": [], "score": -1 },
-      "blue": { "team_keys": [], "score": -1 }
+      "red": {
+        "team_keys": [],
+        "score": -1
+      },
+      "blue": {
+        "team_keys": [],
+        "score": -1
+      }
     },
-    "winning_alliance": ""
+    "winning_alliance": "",
+    "time": 1774908600,
+    "predicted_time": 1774909185
   }
 ]

--- a/static/test-data/schedule.json
+++ b/static/test-data/schedule.json
@@ -21,7 +21,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774882800,
+    "predicted_time": 1774882800,
+    "actual_time": 1774882810
   },
   {
     "comp_level": "qm",
@@ -45,7 +48,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774883280,
+    "predicted_time": 1774883310,
+    "actual_time": 1774883320
   },
   {
     "comp_level": "qm",
@@ -69,7 +75,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774883760,
+    "predicted_time": 1774883820,
+    "actual_time": 1774883830
   },
   {
     "comp_level": "qm",
@@ -93,7 +102,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774884240,
+    "predicted_time": 1774884330,
+    "actual_time": 1774884340
   },
   {
     "comp_level": "qm",
@@ -117,7 +129,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774884720,
+    "predicted_time": 1774884840,
+    "actual_time": 1774884850
   },
   {
     "comp_level": "qm",
@@ -141,7 +156,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774885200,
+    "predicted_time": 1774885350,
+    "actual_time": 1774885360
   },
   {
     "comp_level": "qm",
@@ -165,7 +183,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774885680,
+    "predicted_time": 1774885860,
+    "actual_time": 1774885870
   },
   {
     "comp_level": "qm",
@@ -189,7 +210,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774886160,
+    "predicted_time": 1774886370,
+    "actual_time": 1774886380
   },
   {
     "comp_level": "qm",
@@ -213,7 +237,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774886640,
+    "predicted_time": 1774886880,
+    "actual_time": 1774886890
   },
   {
     "comp_level": "qm",
@@ -237,7 +264,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774887120,
+    "predicted_time": 1774887390,
+    "actual_time": 1774887400
   },
   {
     "comp_level": "qm",
@@ -261,7 +291,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774887600,
+    "predicted_time": 1774887900,
+    "actual_time": 1774887910
   },
   {
     "comp_level": "qm",
@@ -285,7 +318,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774888080,
+    "predicted_time": 1774888410,
+    "actual_time": 1774888420
   },
   {
     "comp_level": "qm",
@@ -309,7 +345,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774888560,
+    "predicted_time": 1774888920,
+    "actual_time": 1774888930
   },
   {
     "comp_level": "qm",
@@ -333,7 +372,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774889040,
+    "predicted_time": 1774889430,
+    "actual_time": 1774889440
   },
   {
     "comp_level": "qm",
@@ -357,7 +399,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774889520,
+    "predicted_time": 1774889940,
+    "actual_time": 1774889950
   },
   {
     "comp_level": "qm",
@@ -381,7 +426,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774890000,
+    "predicted_time": 1774890450,
+    "actual_time": 1774890460
   },
   {
     "comp_level": "qm",
@@ -405,7 +453,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774890480,
+    "predicted_time": 1774890960,
+    "actual_time": 1774890970
   },
   {
     "comp_level": "qm",
@@ -429,7 +480,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774890960,
+    "predicted_time": 1774891470,
+    "actual_time": 1774891480
   },
   {
     "comp_level": "qm",
@@ -453,7 +507,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774891440,
+    "predicted_time": 1774891980,
+    "actual_time": 1774891990
   },
   {
     "comp_level": "qm",
@@ -477,7 +534,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774891920,
+    "predicted_time": 1774892490,
+    "actual_time": 1774892500
   },
   {
     "comp_level": "qm",
@@ -501,7 +561,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774892400,
+    "predicted_time": 1774893000,
+    "actual_time": 1774893010
   },
   {
     "comp_level": "qm",
@@ -525,7 +588,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774892880,
+    "predicted_time": 1774893510,
+    "actual_time": 1774893520
   },
   {
     "comp_level": "qm",
@@ -549,7 +615,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774893360,
+    "predicted_time": 1774894020,
+    "actual_time": 1774894030
   },
   {
     "comp_level": "qm",
@@ -573,7 +642,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774893840,
+    "predicted_time": 1774894530,
+    "actual_time": 1774894540
   },
   {
     "comp_level": "qm",
@@ -597,7 +669,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774894320,
+    "predicted_time": 1774895040,
+    "actual_time": 1774895050
   },
   {
     "comp_level": "qm",
@@ -621,7 +696,10 @@
       }
     },
     "winning_alliance": "blue",
-    "videos": []
+    "videos": [],
+    "time": 1774894800,
+    "predicted_time": 1774895550,
+    "actual_time": 1774895560
   },
   {
     "comp_level": "qm",
@@ -645,7 +723,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774895280,
+    "predicted_time": 1774896060,
+    "actual_time": 1774896070
   },
   {
     "comp_level": "qm",
@@ -669,7 +750,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774895760,
+    "predicted_time": 1774896570,
+    "actual_time": 1774896580
   },
   {
     "comp_level": "qm",
@@ -693,7 +777,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774896240,
+    "predicted_time": 1774897080,
+    "actual_time": 1774897090
   },
   {
     "comp_level": "qm",
@@ -717,7 +804,10 @@
       }
     },
     "winning_alliance": "red",
-    "videos": []
+    "videos": [],
+    "time": 1774896720,
+    "predicted_time": 1774897590,
+    "actual_time": 1774897600
   },
   {
     "comp_level": "qm",
@@ -741,7 +831,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774897200,
+    "predicted_time": 1774898100
   },
   {
     "comp_level": "qm",
@@ -765,7 +857,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774897680,
+    "predicted_time": 1774898610
   },
   {
     "comp_level": "qm",
@@ -789,7 +883,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774898160,
+    "predicted_time": 1774899120
   },
   {
     "comp_level": "qm",
@@ -813,7 +909,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774898640,
+    "predicted_time": 1774899630
   },
   {
     "comp_level": "qm",
@@ -837,7 +935,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774899120,
+    "predicted_time": 1774900140
   },
   {
     "comp_level": "qm",
@@ -861,7 +961,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774899600,
+    "predicted_time": 1774900650
   },
   {
     "comp_level": "qm",
@@ -885,7 +987,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774900080,
+    "predicted_time": 1774901160
   },
   {
     "comp_level": "qm",
@@ -909,7 +1013,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774900560,
+    "predicted_time": 1774901670
   },
   {
     "comp_level": "qm",
@@ -933,7 +1039,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774901040,
+    "predicted_time": 1774902180
   },
   {
     "comp_level": "qm",
@@ -957,7 +1065,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774901520,
+    "predicted_time": 1774902690
   },
   {
     "comp_level": "qm",
@@ -981,7 +1091,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774902000,
+    "predicted_time": 1774903200
   },
   {
     "comp_level": "qm",
@@ -1005,7 +1117,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774902480,
+    "predicted_time": 1774903710
   },
   {
     "comp_level": "qm",
@@ -1029,7 +1143,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774902960,
+    "predicted_time": 1774904220
   },
   {
     "comp_level": "qm",
@@ -1053,7 +1169,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774903440,
+    "predicted_time": 1774904730
   },
   {
     "comp_level": "qm",
@@ -1077,7 +1195,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774903920,
+    "predicted_time": 1774905240
   },
   {
     "comp_level": "qm",
@@ -1101,7 +1221,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774904400,
+    "predicted_time": 1774905750
   },
   {
     "comp_level": "qm",
@@ -1125,7 +1247,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774904880,
+    "predicted_time": 1774906260
   },
   {
     "comp_level": "qm",
@@ -1149,7 +1273,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774905360,
+    "predicted_time": 1774906770
   },
   {
     "comp_level": "qm",
@@ -1173,7 +1299,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774905840,
+    "predicted_time": 1774907280
   },
   {
     "comp_level": "qm",
@@ -1197,7 +1325,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774906320,
+    "predicted_time": 1774907790
   },
   {
     "comp_level": "qm",
@@ -1221,7 +1351,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774906800,
+    "predicted_time": 1774908300
   },
   {
     "comp_level": "qm",
@@ -1245,7 +1377,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774907280,
+    "predicted_time": 1774908810
   },
   {
     "comp_level": "qm",
@@ -1269,7 +1403,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774907760,
+    "predicted_time": 1774909320
   },
   {
     "comp_level": "qm",
@@ -1293,7 +1429,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774908240,
+    "predicted_time": 1774909830
   },
   {
     "comp_level": "qm",
@@ -1317,7 +1455,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774908720,
+    "predicted_time": 1774910340
   },
   {
     "comp_level": "qm",
@@ -1341,7 +1481,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774909200,
+    "predicted_time": 1774910850
   },
   {
     "comp_level": "qm",
@@ -1365,7 +1507,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774909680,
+    "predicted_time": 1774911360
   },
   {
     "comp_level": "qm",
@@ -1389,7 +1533,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774910160,
+    "predicted_time": 1774911870
   },
   {
     "comp_level": "qm",
@@ -1413,7 +1559,9 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774910640,
+    "predicted_time": 1774912380
   },
   {
     "comp_level": "qm",
@@ -1437,6 +1585,8 @@
       }
     },
     "winning_alliance": "",
-    "videos": []
+    "videos": [],
+    "time": 1774911120,
+    "predicted_time": 1774912890
   }
 ]


### PR DESCRIPTION
## Summary

Major overhaul of the Scouting Dashboard's **Overview tab** adding a Data View toggle, match time display, full schedule support, playoff match integration, and several critical bug fixes.

## New Features

### 1. Data View Toggle
- Added **Schedule / Data View** pill toggle in the Team Focus sidebar
- **Schedule View** (default): Shows match cards with alliance teams and status
- **Data View**: Expands Team Focus card with performance stats and enriches match cards with predictions

### 2. Team Focus Card — Expanded Stats (Data View)
- **EPA** (Statbotics) and **OPR** (TBA) side by side
- **Event Rank** from TBA event rankings (not global Statbotics rank)
- **Win-Loss Record** counting both qual and playoff matches
- **RP Rates** (RP1/RP2/RP3 from Statbotics)
- **Team Issues** panel showing cards, deaths, mechanical breakdowns, and tips

### 3. Match Card Predictions (Data View)
- Per-match **win probability** with red/blue percentage and color-coded bar
- **Alliance EPA totals** shown next to each alliance label
- **RP Projection cards** (RPCards component) for both red and blue alliances
- **Alliance partner warnings**: yellow/red cards, deaths, mechanical issues, tipping — shown per-partner with counts

### 4. Scheduled & Predicted Match Times
- Match cards now display **Scheduled time** (clock icon) from TBA's `time` field
- **Predicted time** (lightning icon) from TBA's `predicted_time` field
- Predicted time highlights in **yellow** when running behind schedule
- Only shown when time differs from scheduled (avoids redundancy)
- Works for both qual and playoff matches

### 5. Full Schedule View (No Team Filter)
- When no team is entered, Overview now shows **all event matches** instead of an empty placeholder
- Header shows total match count

### 6. Playoff Match Integration
- When a team is on a playoff alliance, their **bracket path** is appended after qual matches
- Shows played playoff results and upcoming bracket matches with predictions
- Playoff cards labeled with bracket match labels (M1, M7, M11, etc.)

### 7. Bumper Swap Indicator Redesign
- Moved bumper swap from **inside** the match card to a **separate divider card** between matches
- Orange dashed-line design with swap icon — clearer that the swap happens *between* matches

## Bug Fixes

### Critical: Playoff Bracket Predictions Completely Wrong
**Root cause**: `playoffResultMap` key collision. Grand Finals matches (`comp_level: 'f'`) share `set_number: 1` with the first semifinal match (`comp_level: 'sf'`, `set_number: 1`). The old code ran two `forEach` loops over `playoffSchedule`, and the Grand Finals entry (with `winning_alliance: ""`) overwrote M1's actual semifinal result. This caused the truthiness check `actual.winning_alliance` to fail for M1, making ALL bracket matches fall through to EPA predictions instead of using actual results. The entire bracket cascade was wrong.

**Fix**: Consolidated into a single `forEach` that filters by `comp_level` — `'sf'` matches map by `set_number`, while `'f'` matches map to M14 (match 1) and M15 (tiebreaker match 2).

### Critical: Svelte Reactivity Not Tracking `playoffSchedule`
**Root cause**: `bracketSimulation` reactive referenced `playoffSchedule` only inside a nested IIFE function body. Svelte 4's `$:` reactivity may not track dependencies accessed inside nested functions.

**Fix**: Pass `playoffSchedule` as an explicit parameter to the IIFE: `})(playoffOverrides, playoffSchedule)`.

### Bug: Event Rank Showed Global Statbotics Rank
Displayed world EPA ranking instead of event-specific rank. Fixed to use `eventRankings` from TBA.

### Bug: Win-Loss Record Only Counted Quals
Filter `!m.isPlayoff` excluded playoff matches from the record. Removed the filter so both qual and playoff results count.

### Bug: Playoff Score Mapping Inverted
Original code had conditional score assignment (`bm.winner === bm.a2 ? bm.blueScore : bm.redScore`) that gave wrong scores when the winner wasn't a2. Fixed to use direct `bm.redScore`/`bm.blueScore`.

## Infrastructure Changes (Playoff Backend)

These changes are in the `bracketSimulation` reactive block and `overviewTeamSchedule` — they affect how playoff data flows through the system:

| Change | What | Why |
|--------|------|-----|
| `playoffResultMap` construction | Single `forEach` with `comp_level` filter replacing two separate loops | Prevents key collision between SF and Finals matches |
| `bracketSimulation` IIFE params | Added `playoffSchedule` as explicit parameter | Ensures Svelte reactivity tracks playoff schedule changes |
| `overviewTeamSchedule` | Complete rewrite from simple filter to IIFE with `enrichMatch` helper | Supports: no-team full schedule, playoff match injection, time data passthrough |
| `getTeamPlayoffAllianceIndex()` | New helper function | Maps team number → alliance index via `effectiveAlliances` |
| `getOverviewMatchPrediction()` | New helper function | Computes per-match win probability, EPA totals, RP projections for both alliances |
| `getTeamWarnings()` | New helper function | Aggregates card/death/mech/tip counts from scouting data for partner warnings |
| `formatMatchTime()` | New helper function | Formats Unix timestamps to readable date/time strings |
| Playoff match time passthrough | Looks up TBA match by bracket label → `set_number`/`comp_level` mapping | Attaches `time`, `predicted_time`, `actual_time` to playoff cards |

## Test Data Changes

- `static/test-data/schedule.json` — Added `time`, `predicted_time`, `actual_time` fields with realistic timestamps (8-min intervals starting 9 AM, with progressive drift)
- `static/test-data/playoff-schedule.json` — Added same time fields (10-min intervals starting 2 PM)

## Test plan
- [ ] Overview with no team entered → full schedule displayed
- [ ] Enter team 1757, Schedule view → filtered qual + playoff matches
- [ ] Toggle Data View → Team Focus shows EPA, OPR, Event Rank, Record, RP rates, issues
- [ ] Data View match cards show win probability, RP projections, partner warnings
- [ ] Match times show Scheduled and Predicted (yellow when behind)
- [ ] Bumper Swap divider appears between matches 35→45 and 53→60
- [ ] Playoff cards show correct bracket path (M1/M7 played, M11/M13 upcoming for Alliance 1)
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)