### PR TITLE
Add Performance Trends chart and Strength of Schedule to Overview

### DIFF
--- a/src/routes/scouting-dashboard/+page.svelte
+++ b/src/routes/scouting-dashboard/+page.svelte
@@ -66,6 +66,7 @@
 	let simBlueTeams = ['', '', ''];
 	let overviewTeam = '1757';
 	let overviewDataView = false;
+	let showSosLeaderboard = false;
 	let quickLinksOpen = false;
 	let isFullscreen = false;
 	let matchOverrides = new Map();
@@ -1842,6 +1843,88 @@
 		return effectiveAlliances.findIndex(a =>
 			a.captain === teamNum || (a.picks && a.picks.includes(teamNum)) || (a.allPicks && a.allPicks.includes(teamNum))
 		);
+	}
+
+	function computeEventSOS() {
+		if (schedule.length === 0 || teamStatsMap.size === 0) return new Map();
+
+		const playedMatches = schedule.filter(m => {
+			const rs = m.alliances?.red?.score ?? -1;
+			const bs = m.alliances?.blue?.score ?? -1;
+			return rs >= 0 && bs >= 0 && (rs > 0 || bs > 0);
+		});
+
+		if (playedMatches.length === 0) return new Map();
+
+		// Collect all teams
+		const allTeams = new Set();
+		schedule.forEach(m => {
+			if (!m.alliances) return;
+			m.alliances.red.team_keys.forEach(k => allTeams.add(k.replace('frc', '')));
+			m.alliances.blue.team_keys.forEach(k => allTeams.add(k.replace('frc', '')));
+		});
+
+		// Compute average EPA across all event teams for normalization
+		let totalEpa = 0, epaCount = 0;
+		allTeams.forEach(t => {
+			const epa = teamStatsMap.get(t)?.epa || 0;
+			totalEpa += epa;
+			epaCount++;
+		});
+		const avgEventEpa = epaCount > 0 ? totalEpa / epaCount : 0;
+
+		// For each team, compute avg opponent EPA and avg partner EPA
+		const sosRaw = new Map();
+		allTeams.forEach(teamNum => {
+			let oppEpaSum = 0, oppCount = 0;
+			let partnerEpaSum = 0, partnerCount = 0;
+
+			playedMatches.forEach(m => {
+				const redKeys = m.alliances.red.team_keys.map(k => k.replace('frc', ''));
+				const blueKeys = m.alliances.blue.team_keys.map(k => k.replace('frc', ''));
+				const isRed = redKeys.includes(teamNum);
+				const isBlue = blueKeys.includes(teamNum);
+				if (!isRed && !isBlue) return;
+
+				const partners = isRed ? redKeys : blueKeys;
+				const opponents = isRed ? blueKeys : redKeys;
+
+				opponents.forEach(t => {
+					oppEpaSum += teamStatsMap.get(t)?.epa || 0;
+					oppCount++;
+				});
+				partners.forEach(t => {
+					if (t !== teamNum) {
+						partnerEpaSum += teamStatsMap.get(t)?.epa || 0;
+						partnerCount++;
+					}
+				});
+			});
+
+			const avgOppEpa = oppCount > 0 ? oppEpaSum / oppCount : 0;
+			const avgPartnerEpa = partnerCount > 0 ? partnerEpaSum / partnerCount : 0;
+
+			// SOS = how hard was the schedule
+			// Higher opponent EPA = harder, Lower partner EPA = harder
+			// Normalize: (avgOpp - eventAvg) - (avgPartner - eventAvg) = avgOpp - avgPartner
+			// Then shift so positive = harder schedule
+			const sosValue = (avgOppEpa - avgPartnerEpa);
+
+			sosRaw.set(teamNum, {
+				avgOppEpa,
+				avgPartnerEpa,
+				sosValue,
+				rank: 0 // filled below
+			});
+		});
+
+		// Rank by SOS (highest = hardest schedule = rank 1)
+		const sorted = [...sosRaw.entries()].sort((a, b) => b[1].sosValue - a[1].sosValue);
+		sorted.forEach(([team, data], idx) => {
+			data.rank = idx + 1;
+		});
+
+		return sosRaw;
 	}
 
 	function getOverviewTrendData(teamNum) {
@@ -3765,6 +3848,33 @@
 													</div>
 												</div>
 											</div>
+											{#each [computeEventSOS()] as sosMap}
+												{#if sosMap.size > 0 && sosMap.has(overviewTeam)}
+													{@const sos = sosMap.get(overviewTeam)}
+													<button
+														on:click={() => showSosLeaderboard = true}
+														class="w-full p-3 bg-cyan-500/5 border border-cyan-500/20 rounded-xl text-left hover:border-cyan-500/40 transition-all group">
+														<div class="flex items-center justify-between mb-1">
+															<p class="text-[8px] font-black text-cyan-400 uppercase tracking-widest">Strength of Schedule</p>
+															<span class="text-[7px] font-bold text-zinc-600 group-hover:text-cyan-400 transition">View All →</span>
+														</div>
+														<div class="flex items-baseline gap-2">
+															<p class="text-xl font-black text-white">{sos.sosValue >= 0 ? '+' : ''}{sos.sosValue.toFixed(1)}</p>
+															<p class="text-[10px] font-bold text-cyan-400/70">{sos.rank}{sos.rank === 1 ? 'st' : sos.rank === 2 ? 'nd' : sos.rank === 3 ? 'rd' : 'th'} hardest of {sosMap.size}</p>
+														</div>
+														<div class="grid grid-cols-2 gap-2 mt-2 text-center">
+															<div>
+																<p class="text-[10px] font-black text-white">{sos.avgOppEpa.toFixed(1)}</p>
+																<p class="text-[7px] text-zinc-500 font-bold">Avg Opp EPA</p>
+															</div>
+															<div>
+																<p class="text-[10px] font-black text-white">{sos.avgPartnerEpa.toFixed(1)}</p>
+																<p class="text-[7px] text-zinc-500 font-bold">Avg Partner EPA</p>
+															</div>
+														</div>
+													</button>
+												{/if}
+											{/each}
 											{#each [getTeamWarnings(overviewTeam)] as teamWarn}
 												{#if teamWarn.cardCount > 0 || teamWarn.diedCount > 0 || teamWarn.mechCount > 0 || teamWarn.tippedCount > 0}
 													<div class="p-3 bg-red-500/5 border border-red-500/20 rounded-xl">
@@ -4387,6 +4497,48 @@
 						</section>
 					</div>
 				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- SOS Leaderboard Modal -->
+{#if showSosLeaderboard}
+	{@const sosMap = computeEventSOS()}
+	{@const sosList = [...sosMap.entries()].sort((a, b) => b[1].sosValue - a[1].sosValue)}
+	<div class="fixed inset-0 z-[120] flex items-center justify-center p-2 md:p-4 bg-black/95 backdrop-blur-2xl animate-in fade-in zoom-in-95 duration-200"
+		role="dialog"
+		aria-modal="true"
+		on:click|self={() => showSosLeaderboard = false}
+		on:keydown={(e) => e.key === 'Escape' && (showSosLeaderboard = false)}>
+		<div class="bg-[#0a0a0a] border-2 border-zinc-800 rounded-[2rem] w-full max-w-lg max-h-[80vh] overflow-hidden shadow-[0_0_150px_rgba(0,0,0,1)] flex flex-col">
+			<div class="p-6 border-b-2 border-zinc-800 flex justify-between items-center flex-shrink-0">
+				<div>
+					<h2 class="text-xl font-black text-cyan-400 uppercase tracking-tighter">Strength of Schedule</h2>
+					<p class="text-[10px] text-zinc-500 font-bold uppercase tracking-widest mt-1">Sorted by schedule difficulty (hardest first)</p>
+				</div>
+				<button on:click={() => showSosLeaderboard = false} class="w-10 h-10 flex items-center justify-center bg-zinc-900 hover:bg-red-600 rounded-xl transition text-zinc-400 hover:text-white"><span class="text-xl">✕</span></button>
+			</div>
+			<div class="overflow-y-auto flex-1 p-4">
+				<div class="space-y-1">
+					{#each sosList as [team, data], idx}
+						{@const isActive = team === overviewTeam}
+						<button
+							on:click={() => { overviewTeam = team; showSosLeaderboard = false; }}
+							class="w-full flex items-center gap-3 px-3 py-2 rounded-xl transition-all {isActive ? 'bg-cyan-500/10 border border-cyan-500/30' : 'hover:bg-zinc-800/50 border border-transparent'}">
+							<span class="text-[10px] font-black text-zinc-600 w-6 text-right">{idx + 1}</span>
+							<span class="text-sm font-black {isActive ? 'text-cyan-400' : 'text-white'} w-16">{team}</span>
+							<span class="text-[10px] font-bold text-zinc-500 flex-1 truncate">{teamDetailsMap.get(team)?.nickname || ''}</span>
+							<div class="text-right flex-shrink-0">
+								<span class="text-sm font-black {data.sosValue >= 0 ? 'text-red-400' : 'text-green-400'}">{data.sosValue >= 0 ? '+' : ''}{data.sosValue.toFixed(1)}</span>
+								<div class="flex gap-3 text-[8px] text-zinc-600 font-bold">
+									<span>Opp: {data.avgOppEpa.toFixed(0)}</span>
+									<span>Ptr: {data.avgPartnerEpa.toFixed(0)}</span>
+								</div>
+							</div>
+						</button>
+					{/each}
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/routes/scouting-dashboard/+page.svelte
+++ b/src/routes/scouting-dashboard/+page.svelte
@@ -1844,6 +1844,192 @@
 		);
 	}
 
+	function getOverviewTrendData(teamNum) {
+		if (!teamNum || schedule.length === 0) return null;
+
+		// Get played matches for this team in match order
+		const teamMatches = schedule
+			.filter(m => teamIsInMatch(teamNum, m))
+			.sort((a, b) => a.match_number - b.match_number);
+
+		const playedMatches = teamMatches.filter(m => {
+			const rs = m.alliances?.red?.score ?? -1;
+			const bs = m.alliances?.blue?.score ?? -1;
+			return rs >= 0 && bs >= 0 && (rs > 0 || bs > 0);
+		});
+
+		if (playedMatches.length < 2) return null;
+
+		const labels = playedMatches.map(m => `M${m.match_number}`);
+
+		// --- Line 1: Match Score (team's alliance score per match) ---
+		const matchScores = playedMatches.map(m => {
+			const isRed = m.alliances.red.team_keys.includes(`frc${teamNum}`);
+			return isRed ? (m.alliances.red.score || 0) : (m.alliances.blue.score || 0);
+		});
+
+		// --- Line 2: Scout Score (scoring effectiveness per match, 0-5 scale) ---
+		const scoutScores = playedMatches.map(m => {
+			const row = scoutingData.find(r => getVal(r, 'Team #') === teamNum && getVal(r, 'Match #') == m.match_number);
+			return row ? (parseFloat(getVal(row, 'Scoring effectiveness?')) || 0) : null;
+		});
+
+		// --- Line 3: Rank Over Time (computed from cumulative RP for ALL teams) ---
+		const playedSchedule = schedule.filter(m => {
+			const rs = m.alliances?.red?.score ?? -1;
+			const bs = m.alliances?.blue?.score ?? -1;
+			return rs >= 0 && bs >= 0 && (rs > 0 || bs > 0);
+		}).sort((a, b) => a.match_number - b.match_number);
+
+		// Track cumulative RP for all teams
+		const teamRPs = new Map();
+		const teamWins = new Map();
+		const allTeams = new Set();
+		schedule.forEach(m => {
+			if (!m.alliances) return;
+			m.alliances.red.team_keys.forEach(k => allTeams.add(k.replace('frc', '')));
+			m.alliances.blue.team_keys.forEach(k => allTeams.add(k.replace('frc', '')));
+		});
+		allTeams.forEach(t => { teamRPs.set(t, 0); teamWins.set(t, 0); });
+
+		// Build rank snapshots at each match the focused team played
+		const rankOverTime = [];
+		let nextTeamMatchIdx = 0;
+		const teamPlayedNums = new Set(playedMatches.map(m => m.match_number));
+
+		playedSchedule.forEach(m => {
+			const rs = m.alliances.red.score || 0;
+			const bs = m.alliances.blue.score || 0;
+			const redWon = rs > bs;
+			const blueWon = bs > rs;
+
+			// Award 2 RP for win, 1 for tie
+			m.alliances.red.team_keys.forEach(k => {
+				const t = k.replace('frc', '');
+				teamRPs.set(t, (teamRPs.get(t) || 0) + (redWon ? 2 : blueWon ? 0 : 1));
+				if (redWon) teamWins.set(t, (teamWins.get(t) || 0) + 1);
+			});
+			m.alliances.blue.team_keys.forEach(k => {
+				const t = k.replace('frc', '');
+				teamRPs.set(t, (teamRPs.get(t) || 0) + (blueWon ? 2 : redWon ? 0 : 1));
+				if (blueWon) teamWins.set(t, (teamWins.get(t) || 0) + 1);
+			});
+
+			// If this is a match our team played, snapshot the rank
+			if (teamPlayedNums.has(m.match_number)) {
+				// Sort all teams by RP desc, then wins desc
+				const sorted = [...allTeams].sort((a, b) => {
+					const rpDiff = (teamRPs.get(b) || 0) - (teamRPs.get(a) || 0);
+					if (rpDiff !== 0) return rpDiff;
+					return (teamWins.get(b) || 0) - (teamWins.get(a) || 0);
+				});
+				const rank = sorted.indexOf(teamNum) + 1;
+				rankOverTime.push(rank);
+			}
+		});
+
+		// Determine scales
+		const maxScore = Math.max(...matchScores, 100);
+		const maxRank = allTeams.size;
+
+		return {
+			labels,
+			datasets: [
+				{
+					label: 'Alliance Score',
+					data: matchScores,
+					borderColor: '#8b5cf6',
+					backgroundColor: 'rgba(139, 92, 246, 0.1)',
+					tension: 0.3,
+					pointBackgroundColor: '#8b5cf6',
+					pointRadius: 3,
+					borderWidth: 2,
+					yAxisID: 'yScore'
+				},
+				{
+					label: 'Scout Score (0-5)',
+					data: scoutScores,
+					borderColor: '#3b82f6',
+					backgroundColor: 'rgba(59, 130, 246, 0.1)',
+					tension: 0.3,
+					pointBackgroundColor: '#3b82f6',
+					pointRadius: 3,
+					borderWidth: 2,
+					spanGaps: true,
+					yAxisID: 'yScout'
+				},
+				{
+					label: 'Event Rank',
+					data: rankOverTime,
+					borderColor: '#f59e0b',
+					backgroundColor: 'rgba(245, 158, 11, 0.1)',
+					tension: 0.3,
+					pointBackgroundColor: '#f59e0b',
+					pointRadius: 3,
+					borderWidth: 2,
+					borderDash: [4, 4],
+					yAxisID: 'yRank'
+				}
+			],
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				interaction: { mode: 'index', intersect: false },
+				scales: {
+					yScore: {
+						type: 'linear',
+						position: 'left',
+						min: 0,
+						max: Math.ceil(maxScore / 50) * 50,
+						ticks: { color: '#8b5cf6', font: { weight: 'bold', size: 8 } },
+						grid: { color: '#18181b' },
+						title: { display: true, text: 'Score', color: '#8b5cf6', font: { size: 8, weight: 'bold' } }
+					},
+					yScout: {
+						type: 'linear',
+						position: 'right',
+						min: 0,
+						max: 5,
+						ticks: { color: '#3b82f6', font: { weight: 'bold', size: 8 } },
+						grid: { display: false },
+						title: { display: true, text: 'Scout', color: '#3b82f6', font: { size: 8, weight: 'bold' } }
+					},
+					yRank: {
+						type: 'linear',
+						position: 'right',
+						min: 1,
+						max: maxRank,
+						reverse: true,
+						ticks: { color: '#f59e0b', font: { weight: 'bold', size: 8 }, stepSize: Math.ceil(maxRank / 5) },
+						grid: { display: false },
+						title: { display: true, text: 'Rank', color: '#f59e0b', font: { size: 8, weight: 'bold' } }
+					},
+					x: {
+						ticks: { color: '#3f3f46', font: { weight: 'bold', size: 8 } },
+						grid: { display: false }
+					}
+				},
+				plugins: {
+					legend: {
+						position: 'top',
+						align: 'end',
+						labels: { color: '#71717a', font: { weight: 'bold', size: 8 }, usePointStyle: true, padding: 10 }
+					},
+					tooltip: {
+						callbacks: {
+							label: (ctx) => {
+								const val = ctx.parsed.y;
+								if (ctx.dataset.label === 'Event Rank') return `Rank: #${val}`;
+								if (ctx.dataset.label === 'Scout Score (0-5)') return `Scout: ${val?.toFixed(1) ?? '—'}/5`;
+								return `Score: ${val}`;
+							}
+						}
+					}
+				}
+			}
+		};
+	}
+
 	function enterDebugMode(mode) {
 		debugMode = mode;
 		localStorage.removeItem('scouting_cache');
@@ -3588,6 +3774,16 @@
 															{#if teamWarn.diedCount > 0}<p>Died in {teamWarn.diedCount} match{teamWarn.diedCount > 1 ? 'es' : ''}</p>{/if}
 															{#if teamWarn.mechCount > 0}<p>Mech issue in {teamWarn.mechCount} match{teamWarn.mechCount > 1 ? 'es' : ''}</p>{/if}
 															{#if teamWarn.tippedCount > 0}<p>Tipped in {teamWarn.tippedCount} match{teamWarn.tippedCount > 1 ? 'es' : ''}</p>{/if}
+														</div>
+													</div>
+												{/if}
+											{/each}
+											{#each [getOverviewTrendData(overviewTeam)] as trendData}
+												{#if trendData}
+													<div class="p-3 bg-zinc-800/50 border border-zinc-700 rounded-xl">
+														<p class="text-[8px] font-black text-zinc-400 uppercase tracking-widest mb-2">Performance Trends</p>
+														<div class="h-48">
+															<Line data={{ labels: trendData.labels, datasets: trendData.datasets }} options={trendData.options} />
 														</div>
 													</div>
 												{/if}


### PR DESCRIPTION
## Summary

Two new analytics features for the Overview tab's Data View, building on the enhancements merged in #138.

## New Features

### 1. Performance Trends Chart

Three-axis line chart in the Team Focus sidebar showing performance over played matches:

- **Alliance Score** (purple, left axis) — team's alliance score per match
- **Scout Score** (blue, right axis) — scouting effectiveness rating (0-5 scale)
- **Event Rank** (orange dashed, right axis, inverted) — computed rank position after each match based on cumulative ranking points and wins across all event teams

Uses the existing Chart.js / svelte-chartjs `<Line>` component. All data computed locally from schedule results and scouting data — no additional API calls.

**How rank-over-time works:** After each played match in the schedule, the function accumulates ranking points (2 for win, 1 for tie, 0 for loss) for ALL teams, then sorts to determine each team's rank position at that point. Only snapshots at matches the focused team played in are shown.

### 2. Strength of Schedule (SOS)

Simplified SOS metric inspired by [Statbotics' approach](https://www.statbotics.io/blog/sos), computed from locally available data:

- **Average Opponent EPA** — mean EPA of all opponents faced across played matches
- **Average Partner EPA** — mean EPA of alliance partners (excluding the team itself)
- **SOS Value** = Avg Opponent EPA - Avg Partner EPA
  - Positive = harder schedule (strong opponents, weak partners)
  - Negative = easier schedule (weak opponents, strong partners)
- Ranked across all event teams (1st = hardest schedule)

**SOS Card** in the Team Focus sidebar shows:
- SOS value with sign indicator
- Rank (e.g., "24th hardest of 32")
- Average Opponent EPA and Average Partner EPA breakdown
- "View All →" link

**SOS Leaderboard Modal** (click the card):
- Full event roster sorted by schedule difficulty (hardest first)
- Each row: rank, team number, team name, SOS value (color-coded), Opp/Ptr EPA
- Click any team to focus on them in the Overview

**Note:** This is a simplified version of Statbotics' SOS. The full Statbotics method uses Monte Carlo simulation with hundreds of random schedules to compute percentiles. Our approach uses direct EPA comparison which is computationally trivial but still meaningful for identifying schedule imbalance.

## Files Modified

| File | Changes |
|------|---------|
| `src/routes/scouting-dashboard/+page.svelte` | Added `getOverviewTrendData()`, `computeEventSOS()`, `showSosLeaderboard` state, trend chart in Data View, SOS card, SOS leaderboard modal |

## Test plan
- [ ] Overview → team 1757 → Data View → Performance Trends chart shows 3 lines with correct axes
- [ ] Chart x-axis shows only matches the team played in
- [ ] Rank line (orange dashed) is inverted (rank 1 at top)
- [ ] SOS card shows value, rank, avg opponent/partner EPA
- [ ] Click SOS card → leaderboard modal opens sorted by hardest schedule
- [ ] Click a team in leaderboard → focuses on that team, modal closes
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)